### PR TITLE
add `giottoPolygon` `ext<-` method

### DIFF
--- a/.github/workflows/main_check.yml
+++ b/.github/workflows/main_check.yml
@@ -59,7 +59,7 @@ jobs:
           _R_CHECK_RD_XREFS: false
         with:
           dependencies: '"hard"' # do not use suggested dependencies
-          extra-packages: any::rcmdcheck, any::testthat, any::rlang, any::R.utils, any::remotes, any::covr
+          extra-packages: any::rcmdcheck, any::testthat, any::rlang, any::R.utils, any::remotes
 
       - name: Set up dependencies (GiottoData)
         run: |

--- a/R/methods-ext.R
+++ b/R/methods-ext.R
@@ -45,6 +45,32 @@ setMethod('ext', signature('giottoLargeImage'), function(x, ...) {
 
 #' @rdname ext-generic
 #' @export
+setMethod('ext<-', signature(x = 'giottoPoints', value = 'SpatExtent'), function(x, value)
+{
+  old_ext = ext_to_num_vec(ext(x))
+  new_ext = ext_to_num_vec(value)
+  xy_scale = c(diff(new_ext[c(2,1)])/diff(old_ext[c(2,1)]),
+               diff(new_ext[c(4,3)])/diff(old_ext[c(4,3)]))
+  x@spatVector = terra::rescale(x@spatVector, fx = xy_scale[1], fy = xy_scale[2], x0 = old_ext[1L], y0 = old_ext[3L])
+  x = spatShift(x, dx = new_ext[1L] - old_ext[1L], dy = new_ext[3L] - old_ext[3L])
+  x
+})
+
+#' @rdname ext-generic
+#' @export
+setMethod('ext<-', signature(x = 'giottoPolygon', value = 'SpatExtent'), function(x, value)
+{
+  old_ext = ext_to_num_vec(ext(x))
+  new_ext = ext_to_num_vec(value)
+  xy_scale = c(diff(new_ext[c(2,1)])/diff(old_ext[c(2,1)]),
+               diff(new_ext[c(4,3)])/diff(old_ext[c(4,3)]))
+  x = do_gpoly(x, 'terra'::'rescale', args = list(fx = xy_scale[1], fy = xy_scale[2], x0 = old_ext[1L], y0 = old_ext[3L]))
+  x = spatShift(x, dx = new_ext[1L] - old_ext[1L], dy = new_ext[3L] - old_ext[3L])
+  x
+})
+
+#' @rdname ext-generic
+#' @export
 setMethod('ext<-', signature(x = 'giottoLargeImage', value = 'SpatExtent'), function(x, value) {
   terra::ext(x@raster_object) = value
   x
@@ -57,3 +83,11 @@ setMethod('ext<-', signature(x = 'ANY', value = 'ANY'), function(x, value) {
   value = terra::ext(value)
   methods::callGeneric(x, value)
 })
+
+# Helper function to convert a SpatExtent object to a simple numeric vector
+# and strip the names
+ext_to_num_vec = function(x) {
+  out = x[]
+  names(out) = NULL
+  out
+}


### PR DESCRIPTION
- remove extraneous covr installation from main_check github action
- add `ext<-` method for directly setting giottoPoints extent
- add `ext_to_num_vec()` helper to convert SpatExtent to an unnamed numerical vector