### PR TITLE
subset fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GiottoClass
 Title: Giotto Suite object definitions and framework
-Version: 0.0.0.9004
+Version: 0.0.0.9005
 Authors@R: c(
 	person("Ruben", "Dries", email = "rubendries@gmail.com",
 		 role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## Breaking Changes
 
 ## Added
+- Added `ext<-()` method for `giottoPolygon`, `giottoPoints`
+- Added `crop()` method for `giottoLargeImage`, `giottoPoints`
 
 ## Changes
 - Improved performance of gefToGiotto()

--- a/R/methods-coerce.R
+++ b/R/methods-coerce.R
@@ -56,8 +56,9 @@ as.data.table.giottoPoints <- function(x, ...) {
 
 
 # DT -> SpatVector ####
-
 # TODO
+# as.points / as.polygon generics from terra are an option, but terra deals with
+# this kind of conversion using vect() usually
 
 
 

--- a/R/methods_crop.R
+++ b/R/methods_crop.R
@@ -1,12 +1,20 @@
 
+# documentation ####
 
 #' @name crop-generic
 #' @title Crop to a spatial subset
 #' @description see [terra::crop]. Object x will be cropped using object y.
 #' @param x object
 #' @param y any object that has a SpatExtent or returns a SpatExtent
-#' @param ... additional params to pass to terra::crop
+#' @param \dots additional params to pass to terra::crop
 NULL
+
+
+
+
+
+
+# methods ####
 
 
 
@@ -21,3 +29,74 @@ setMethod('crop', signature('giottoLargeImage'), function(x, y, ...) {
 
   x
 })
+
+
+#' @describeIn crop-generic Crop a giottoPoints
+#' @param DT logical. Use alternative DT subsetting for crop operation
+#' @param xmin,xmax,ymin,ymax only used if DT = TRUE. Set extent bounds
+#' independently
+#' @export
+setMethod('crop', signature('giottoPoints'), function(
+    x, y, DT = TRUE, xmin = NULL, xmax = NULL, ymin = NULL, ymax = NULL, ...
+) {
+  checkmate::assert_logical(DT)
+  if(DT) {
+    # converting to DT, subsetting, then regeneration of SpatVector with vect()
+    # is currently faster than using terra::crop() as of 9/21/23
+    missing_y = missing(y)
+    n_single_bounds = 4 - sum(sapply(list(xmin, xmax, ymin, ymax), is.null))
+
+    # check cropping params
+    # ONLY y OR the single spat bounds can be used at any one time
+    if((missing_y && n_single_bounds == 0) ||
+       (!missing_y && n_single_bounds > 0)) {
+      stop(wrap_txt('Crop bounds must be supplied through either a SpatExtent passed to \'y\'
+                    or single numerical bounds passed to one or more of \'xmin\',\'xmax\', \'ymin\', \'ymax\''))
+    }
+
+    # 1. Get full set of cropping bounds
+    if(!missing_y) {
+      # if y is available, use y values directly.
+      # only the extent of y is usable for the DT method
+      if(!inherits(y, 'SpatExtent')) {
+        warning(wrap_txt('Only the extent of y is used when cropping with DT = TRUE'))
+        y = ext(y)
+      }
+
+      xmin = terra::xmin(y)
+      xmax = terra::xmax(y)
+      ymin = terra::ymin(y)
+      ymax = terra::ymax(y)
+
+    } else {
+      # otherwise, fill in any spatial subset bounds that may not have been
+      # supplied with the current extent value(s)
+      current_ext = ext(x)
+      if(is.null(xmin)) xmin = terra::xmin(current_ext)
+      if(is.null(xmax)) xmax = terra::xmax(current_ext)
+      if(is.null(ymin)) ymin = terra::ymin(current_ext)
+      if(is.null(ymax)) ymax = terra::ymax(current_ext)
+    }
+
+    # 2. convert to DT
+    sv = x@spatVector
+    spatDT = as.data.table(sv, geom = 'XY')
+
+    # 3. spatial subset then vect() to SpatVector again
+    spatDT_subset = spatDT[x >= xmin & x <= xmax & y >= ymin & y <= ymax]
+    sv_subset = terra::vect(spatDT_subset, c('x', 'y'))
+
+    # 4. update x
+    x@spatVector = sv_subset
+
+  } else {
+    x@spatVector = terra::crop(x@spatVector, y, ...)
+  }
+
+  # update ID cache and return
+  x@unique_ID_cache = unique(terra::values(x@spatVector)$feat_ID)
+  x
+})
+
+
+

--- a/man/crop-generic.Rd
+++ b/man/crop-generic.Rd
@@ -3,16 +3,24 @@
 \name{crop-generic}
 \alias{crop-generic}
 \alias{crop,giottoLargeImage-method}
+\alias{crop,giottoPoints-method}
 \title{Crop to a spatial subset}
 \usage{
 \S4method{crop}{giottoLargeImage}(x, y, ...)
+
+\S4method{crop}{giottoPoints}(x, y, DT = TRUE, xmin = NULL, xmax = NULL, ymin = NULL, ymax = NULL, ...)
 }
 \arguments{
 \item{x}{object}
 
 \item{y}{any object that has a SpatExtent or returns a SpatExtent}
 
-\item{...}{additional params to pass to terra::crop}
+\item{\dots}{additional params to pass to terra::crop}
+
+\item{DT}{logical. Use alternative DT subsetting for crop operation}
+
+\item{xmin, xmax, ymin, ymax}{only used if DT = TRUE. Set extent bounds
+independently}
 }
 \description{
 see \link[terra:crop]{terra::crop}. Object x will be cropped using object y.
@@ -20,5 +28,7 @@ see \link[terra:crop]{terra::crop}. Object x will be cropped using object y.
 \section{Functions}{
 \itemize{
 \item \code{crop(giottoLargeImage)}: Crop a giottoLargeImage
+
+\item \code{crop(giottoPoints)}: Crop a giottoPoints
 
 }}

--- a/man/subsetGiotto.Rd
+++ b/man/subsetGiotto.Rd
@@ -10,7 +10,6 @@ subsetGiotto(
   feat_type = NULL,
   cell_ids = NULL,
   feat_ids = NULL,
-  gene_ids = NULL,
   poly_info = NULL,
   all_spat_units = TRUE,
   all_feat_types = TRUE,
@@ -32,8 +31,6 @@ subsetGiotto(
 \item{cell_ids}{cell IDs to keep}
 
 \item{feat_ids}{feature IDs to keep}
-
-\item{gene_ids}{deprecated. Use \code{feat_ids}}
 
 \item{poly_info}{polygon information to use}
 

--- a/man/subsetGiotto.Rd
+++ b/man/subsetGiotto.Rd
@@ -28,11 +28,12 @@ subsetGiotto(
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
-\item{cell_ids}{cell IDs to keep}
+\item{cell_ids}{character. cell IDs to keep}
 
-\item{feat_ids}{feature IDs to keep}
+\item{feat_ids}{character. feature IDs to keep}
 
-\item{poly_info}{polygon information to use}
+\item{poly_info}{character. polygon info(s) to subset if present. (defaults
+to be the same as the spat_unit)}
 
 \item{all_spat_units}{subset all spatial units with selected feature ids}
 
@@ -48,7 +49,9 @@ subsetGiotto(
 giotto object
 }
 \description{
-Subsets Giotto object including previous analyses.
+Subsets Giotto object including previous analyses. For subsetting
+the subcellular information only without editing the aggregate information,
+use \link{subsetGiottoLocsSubcellular}
 }
 \details{
 Subsets a Giotto object for a specific spatial unit and feature type

--- a/man/subsetGiottoLocs.Rd
+++ b/man/subsetGiottoLocs.Rd
@@ -42,7 +42,7 @@ to subset to}
 giotto object
 }
 \description{
-Subsets Giotto object based on spatial locations
+Subsets Giotto object based on spatial locations.
 }
 \details{
 Subsets a Giotto based on spatial locations and for one provided spatial unit


### PR DESCRIPTION
- Add `crop()` method for `giottoPoints`. Use the `DT = TRUE` param  for faster rectangular crops. Also supports single/multiboundary crops using the `xmin`,`xmax`,`ymin`,`ymax` params when using `DT = TRUE`. When `DT  = FALSE`, the default terra crop function is used, with access to the additional params through `...`.
- Add `valid_spat_subset_params()` helper
- Update `subset_giotto_points_object()`
- Update `subsetGiottoLocsSubcellular()`
- Remove deprecated `gene_ids` param in `subset_feature_info_data()`
- Link up subsetGiotto to subsetGiottoLocs so that spatial subsetting will be passed properly
- Made sure that all_spat_unit and all_feat_types params are being respected by subset.
- Added documentation and comments on subset workflow
- version bump