### PR TITLE
Add: basic DT-based object subsetting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GiottoClass
 Title: Giotto Suite object definitions and framework
-Version: 0.0.0.9006
+Version: 0.0.0.9007
 Authors@R: c(
 	person("Ruben", "Dries", email = "rubendries@gmail.com",
 		 role = c("aut", "cre")),

--- a/R/classes.R
+++ b/R/classes.R
@@ -33,9 +33,8 @@ setClassUnion('gIndex', c('numeric', 'logical', 'character'))
 
 
 
-
-
 # VIRTUAL CLASSES ####
+
 
 # ** giottoSubobject Class ####
 #' @keywords internal
@@ -43,6 +42,17 @@ setClassUnion('gIndex', c('numeric', 'logical', 'character'))
 setClass(
   'giottoSubobject',
   contains = 'VIRTUAL')
+
+# ** gdtData Class ####
+#' @description
+#' umbrella class for referring to Giotto's normal data.table-based slots for
+#' extraction purposes
+#' @keywords internal
+#' @noRd
+setClass(
+  'gdtData',
+  contains = 'VIRTUAL'
+)
 
 
 # ** nameData Class ####
@@ -76,7 +86,7 @@ setClass("exprData",
 #' @keywords internal
 #' @noRd
 setClass("coordDataDT",
-  contains = "VIRTUAL",
+  contains = c("VIRTUAL", "gdtData"),
   slots = list(coordinates = "data.table"),
   prototype = prototype(coordinates = data.table::data.table())
 )
@@ -99,7 +109,7 @@ setClass("coordDataDT",
 #' @keywords internal
 #' @noRd
 setClass("metaData",
-  contains = "VIRTUAL",
+  contains = c("VIRTUAL", "gdtData"),
   slots = list(
     metaDT = "data.table",
     col_desc = "character"
@@ -119,7 +129,7 @@ setClass("metaData",
 #' @keywords internal
 #' @noRd
 setClass("enrData",
-  contains = "VIRTUAL",
+  contains = c("VIRTUAL", "gdtData"),
   slots = list(
     method = "character",
     enrichDT = "nullOrDatatable"

--- a/R/methods-extract.R
+++ b/R/methods-extract.R
@@ -90,6 +90,61 @@ setMethod('$<-', signature(x = 'terraVectData'),
 
 # [ S4 access generic ####
 
+## * gdtData ####
+
+# Make it so that i and j subsets can be written independently
+#' @rdname extract-methods
+#' @export
+setMethod('[', signature(x = 'gdtData', i = 'ANY', j = 'ANY', drop = 'missing'),
+          function(x, i, j) {
+            x = x[i = i]
+            x = x[j = j]
+            x
+          })
+
+#' @rdname extract-methods
+#' @export
+setMethod('[', signature(x = 'gdtData', i = 'logical', j = 'missing', drop = 'missing'),
+          function(x, i, j) {
+            x_nrow = nrow(x)
+            i_len = length(i)
+
+            if(i_len > x_nrow) {
+              stop('logical subset vector is longer than number of rows',
+                   call. = FALSE)
+            }
+            if (i_len < x_nrow) { # handle recycling
+              i = rep(i, length.out = x_nrow)
+            }
+
+            x[] = x[][i]
+            x
+          })
+
+#' @rdname extract-methods
+#' @export
+setMethod('[', signature(x = 'gdtData', i = 'character', j = 'missing', drop = 'missing'),
+          function(x, i, j) {
+
+            # only appropriate for objects where the spatIDs are in the same
+            # order and number of repeats as the contained data.table
+            x_colnames = colnames(x[])
+            ids = if('cell_ID' %in% x_colnames) spatIDs(x)
+            else if('feat_ID' %in% x_colnames) featIDs(x)
+            else stop(wrap_txt(
+              'Subset object does not contain either cell_ID or feat_ID column'
+            ))
+
+            # make idx vector
+            idx = match(i, ids)
+            x[] = x[][idx]
+            x
+          })
+
+
+
+
+
 ## * coordDataDT ####
 
 
@@ -103,7 +158,6 @@ setMethod('[', signature(x = 'coordDataDT', i = 'missing', j = 'ANY', drop = 'mi
             x@coordinates = x@coordinates[, j = j, with = FALSE]
             x
           })
-
 
 # setMethod('[', signature(x = 'giotto', i = 'character', j = 'missing', drop = 'missing'),
 #           function(x, i, spat_unit = NULL, feat_type = NULL, name = NULL) {
@@ -184,7 +238,7 @@ setReplaceMethod('[', signature(x = 'coordDataDT', i = 'missing', j = 'missing',
 
 #' @rdname extract-methods
 #' @export
-setMethod('[', signature(x = 'giottoPoints', i = "ANY", j = "missing", drop = "missing"),
+setMethod('[', signature(x = 'giottoPoints', i = "gIndex", j = "missing", drop = "missing"),
           function(x, i, j) {
             x@spatVector = x@spatVector[i]
             x@unique_ID_cache = featIDs(x, uniques = TRUE, use_cache = FALSE)

--- a/man/extract-methods.Rd
+++ b/man/extract-methods.Rd
@@ -13,13 +13,16 @@
 \alias{$<-,metaData-method}
 \alias{$,terraVectData-method}
 \alias{$<-,terraVectData-method}
+\alias{[,gdtData,ANY,ANY,missing-method}
+\alias{[,gdtData,logical,missing,missing-method}
+\alias{[,gdtData,character,missing,missing-method}
 \alias{[,coordDataDT,missing,ANY,missing-method}
 \alias{[,coordDataDT,ANY,missing,missing-method}
 \alias{[,coordDataDT,ANY,ANY,missing-method}
 \alias{[,coordDataDT,missing,missing,missing-method}
 \alias{[<-,coordDataDT,missing,missing,ANY-method}
 \alias{[<-,coordDataDT,missing,missing-method}
-\alias{[,giottoPoints,ANY,missing,missing-method}
+\alias{[,giottoPoints,gIndex,missing,missing-method}
 \alias{[,metaData,missing,ANY,missing-method}
 \alias{[,metaData,ANY,missing,missing-method}
 \alias{[,metaData,ANY,ANY,missing-method}
@@ -49,7 +52,6 @@
 \alias{[<-,spatGridData,missing,missing,ANY-method}
 \alias{[<-,spatGridData,missing,missing-method}
 \alias{[,giottoPoints,missing,missing,missing-method}
-\alias{[,giottoPoints,gIndex,missing,missing-method}
 \alias{[,giottoPoints,character,missing,missing-method}
 \alias{[,giottoPoints,missing,gIndex,missing-method}
 \alias{[<-,giottoPoints,missing,missing,ANY-method}
@@ -75,6 +77,12 @@
 
 \S4method{$}{terraVectData}(x, name) <- value
 
+\S4method{[}{gdtData,ANY,ANY,missing}(x, i, j)
+
+\S4method{[}{gdtData,logical,missing,missing}(x, i, j)
+
+\S4method{[}{gdtData,character,missing,missing}(x, i, j)
+
 \S4method{[}{coordDataDT,missing,ANY,missing}(x, i, j)
 
 \S4method{[}{coordDataDT,ANY,missing,missing}(x, i, j)
@@ -85,7 +93,7 @@
 
 \S4method{[}{coordDataDT,missing,missing,ANY}(x, i, j) <- value
 
-\S4method{[}{giottoPoints,ANY,missing,missing}(x, i, j)
+\S4method{[}{giottoPoints,gIndex,missing,missing}(x, i, j)
 
 \S4method{[}{metaData,missing,ANY,missing}(x, i, j)
 


### PR DESCRIPTION
- Add integer index, character, and logical subsetting for spatial enrichments, spatial locations, and metadata objects
- Defined under umbrella class `gdtData`
- bump version number