### PR TITLE
Adjust centroid identification in `polyStamp()`

### DIFF
--- a/R/generate_poly.R
+++ b/R/generate_poly.R
@@ -35,10 +35,10 @@ polyStamp <- function(stamp_dt,
   stamp_dt$part = 0
   stamp_dt$hole = 0
 
-  setcolorder(stamp_dt, neworder = c("geom", "part", "x", "y", "hole"))
+  data.table::setcolorder(stamp_dt, neworder = c("geom", "part", "x", "y", "hole"))
   stamp_poly = terra::vect(as.matrix(stamp_dt), type = "polygons")
 
-  centroid_dt = as.data.table(terra::centroids(stamp_poly),
+  centroid_dt = data.table::as.data.table(terra::centroids(stamp_poly),
                               geom = "XY",
                               include_values = F)
   

--- a/R/generate_poly.R
+++ b/R/generate_poly.R
@@ -29,9 +29,24 @@ polyStamp <- function(stamp_dt,
     stop(wrap_txt('Not all colnames found in spatlocs'))
   }
 
-  # define polys relative to centroid
-  stamp_centroid = c(x = mean(stamp_dt[['x']]),
-                     y = mean(stamp_dt[['y']]))
+  # define polys relative to centroid of stamp_dt
+  # add necessary columns to make a polygon from matrix
+  stamp_dt$geom = 1
+  stamp_dt$part = 0
+  stamp_dt$hole = 0
+
+  setcolorder(stamp_dt, neworder = c("geom", "part", "x", "y", "hole"))
+  stamp_poly = terra::vect(as.matrix(stamp_dt), type = "polygons")
+
+  centroid_dt = spatVector_to_dt2(terra::centroids(stamp_poly),
+                                  include_values = F)
+  
+  stamp_centroid = c(x = centroid_dt$x,
+                     y = centroid_dt$y)
+
+  # stamp_centroid = c(x = mean(stamp_dt[['x']]),
+  #                    y = mean(stamp_dt[['y']]))
+
   rel_vertices = data.table::data.table(x = stamp_dt$x - stamp_centroid[['x']],
                                         y = stamp_dt$y - stamp_centroid[['y']])
 

--- a/R/generate_poly.R
+++ b/R/generate_poly.R
@@ -44,9 +44,6 @@ polyStamp <- function(stamp_dt,
   stamp_centroid = c(x = centroid_dt$x,
                      y = centroid_dt$y)
 
-  # stamp_centroid = c(x = mean(stamp_dt[['x']]),
-  #                    y = mean(stamp_dt[['y']]))
-
   rel_vertices = data.table::data.table(x = stamp_dt$x - stamp_centroid[['x']],
                                         y = stamp_dt$y - stamp_centroid[['y']])
 

--- a/R/generate_poly.R
+++ b/R/generate_poly.R
@@ -38,8 +38,9 @@ polyStamp <- function(stamp_dt,
   setcolorder(stamp_dt, neworder = c("geom", "part", "x", "y", "hole"))
   stamp_poly = terra::vect(as.matrix(stamp_dt), type = "polygons")
 
-  centroid_dt = spatVector_to_dt2(terra::centroids(stamp_poly),
-                                  include_values = F)
+  centroid_dt = as.data.table(terra::centroids(stamp_poly),
+                              geom = "XY",
+                              include_values = F)
   
   stamp_centroid = c(x = centroid_dt$x,
                      y = centroid_dt$y)


### PR DESCRIPTION
Changed centroid identification behavior in function `polyStamp()`.

Previously, the centroid of `stamp_dt` was identified by taking the mean of the vertices (i.e. the columns of this `data.table` argument). Now, `stamp_dt` is coerced to a `spatVector`, and its centroid is calculated with `terra::centroids()`. 

This ensures proper shifting of the vertices in `stamp_dt` to the origin. Downstream, this ensures that the vertices of the polygons are created about each spatial location coordinate almost exactly.