### PR TITLE
spatial converters fixes

### DIFF
--- a/R/giotto_structures.R
+++ b/R/giotto_structures.R
@@ -17,7 +17,10 @@ do_gpoly = function(x, what, args = NULL) {
   }
   if(!is.null(x@overlaps)) {
     x@overlaps = lapply(x@overlaps, function(sv) {
-      if(inherits(sv, 'SpatVector')) {
+      spatial_classes = c(
+        'SpatVector', 'sf', 'SpatialPolygonsDataFrame', 'SpatialPointsDataFrame', 'stars'
+        )
+      if(inherits(sv, spatial_classes)) {
         do.call(what, args = append(list(sv), args))
       } else {
         sv

--- a/R/methods-coerce.R
+++ b/R/methods-coerce.R
@@ -40,7 +40,7 @@ NULL
 
 #' @title Coerce to terra
 #' @name as.terra
-#' @param x The object ot coerce
+#' @param x The object to coerce
 #' @param drop When TRUE, returned object will be the terra object instead of
 #' wrapped in a `giottoPoints` or `giottoPolygon` object
 #' @family As coercion functions
@@ -100,6 +100,7 @@ as.data.table.giottoPoints <- function(x, ...) {
 # Spatial Ecosystem Converters ####
 
 # * to sp ####
+# Spatial class covers both SpatialPolygonsDataFrame and SpatialPointsDataFrame
 
 #' @rdname as.sp
 #' @export
@@ -112,6 +113,7 @@ setMethod('as.sp', signature('sf'), function(x) {
 #' @export
 setMethod('as.sp', signature('SpatVector'), function(x) {
   GiottoUtils::package_check('sp')
+  GiottoUtils::package_check('raster') # needed for this conversion
   as(x, "Spatial")
 })
 
@@ -124,7 +126,7 @@ setMethod('as.sp', signature('stars'), function(x) {
 
 #' @rdname as.sp
 #' @export
-setMethod('as.sp', signature('sp'), function(x) {
+setMethod('as.sp', signature('Spatial'), function(x) {
   GiottoUtils::package_check('sp')
   x
 })
@@ -163,9 +165,9 @@ setMethod('as.sf', signature('SpatVector'), function(x) {
 
 #' @rdname as.sf
 #' @export
-setMethod('as.sf', signature('sp'), function(x) {
+setMethod('as.sf', signature('Spatial'), function(x) {
   GiottoUtils::package_check('sf')
-  sf::st_as_sf()
+  sf::st_as_sf(x)
 })
 
 #' @rdname as.sf
@@ -232,7 +234,7 @@ setMethod('as.stars', signature('sf'),
 
 #' @rdname as.stars
 #' @export
-setMethod('as.stars', signature('sp'),
+setMethod('as.stars', signature('Spatial'),
           function(x) {
             GiottoUtils::package_check('stars')
             stars::st_as_stars(x)
@@ -314,7 +316,7 @@ setMethod('as.terra', signature('stars'),
 
 #' @rdname as.terra
 #' @export
-setMethod('as.terra', signature('sp'), function(x) {
+setMethod('as.terra', signature('Spatial'), function(x) {
   terra::vect(x)
 })
 

--- a/tests/testthat/test_spatial_converters.R
+++ b/tests/testthat/test_spatial_converters.R
@@ -1,0 +1,214 @@
+
+# create dummy data
+points_dt <- data.table::data.table(
+  feat_ID = letters[1:10],
+  x = 1:10,
+  y = 1:10
+)
+
+terra_gpoints <- createGiottoPoints(points_dt)
+terra_gpolys <- GiottoData::loadSubObjectMini('giottoPolygon')[1:20]
+
+# drop = TRUE is expected as default for each of these
+
+# convert from terra ####
+test_that('terra to sf works', {
+  sf_out <- as.sf(terra_gpoints)
+  expect_class(sf_out, 'sf')
+
+  gpoints_out <- as.sf(terra_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'sf')
+
+  gpoly_out <- as.sf(terra_gpolys, drop = FALSE)
+  expect_class(gpoly_out, 'giottoPolygon')
+  expect_class(gpoly_out@spatVector, 'sf')
+  expect_class(gpoly_out@spatVectorCentroids, 'sf')
+  expect_class(gpoly_out@overlaps$rna, 'sf')
+})
+
+test_that('terra to sp works', {
+  sp_out <- as.sp(terra_gpoints)
+  expect_class(sp_out, 'Spatial')
+
+  gpoints_out <- as.sp(terra_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'Spatial')
+
+  # will usually warn about few vertices in the overlaps
+  suppressWarnings(gpoly_out <- as.sp(terra_gpolys, drop = FALSE))
+  expect_class(gpoly_out, 'giottoPolygon')
+  expect_class(gpoly_out@spatVector, 'Spatial')
+  expect_class(gpoly_out@spatVectorCentroids, 'Spatial')
+  expect_class(gpoly_out@overlaps$rna, 'Spatial') # TODO this should be points
+})
+
+test_that('terra to stars works', {
+  stars_out <- as.stars(terra_gpoints)
+  expect_class(stars_out, 'stars')
+
+  gpoints_out <- as.stars(terra_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'stars')
+
+  gpoly_out <- as.stars(terra_gpolys, drop = FALSE)
+  expect_class(gpoly_out, 'giottoPolygon')
+  expect_class(gpoly_out@spatVector, 'stars')
+  expect_class(gpoly_out@spatVectorCentroids, 'stars')
+  expect_class(gpoly_out@overlaps$rna, 'stars')
+})
+
+
+# convert from sf ####
+sf_gpoints <- as.sf(terra_gpoints, drop = FALSE)
+sf_gpolys <- as.sf(terra_gpolys, drop = FALSE)
+
+test_that('sf to terra works', {
+  sf_out <- as.terra(sf_gpoints)
+  expect_class(sf_out, 'SpatVector')
+
+  gpoints_out <- as.terra(sf_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'SpatVector')
+
+  gpoly_out <- as.terra(sf_gpolys, drop = FALSE)
+  expect_class(gpoly_out, 'giottoPolygon')
+  expect_class(gpoly_out@spatVector, 'SpatVector')
+  expect_class(gpoly_out@spatVectorCentroids, 'SpatVector')
+  expect_class(gpoly_out@overlaps$rna, 'SpatVector')
+})
+
+test_that('sf to sp works', {
+  sp_out <- as.sp(sf_gpoints)
+  expect_class(sp_out, 'Spatial')
+
+  gpoints_out <- as.sp(sf_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'Spatial')
+
+  # TODO empty geometries not supported by sp
+  # The return of overlaps info as single vertex polys needs to be fixed first.
+  # suppressWarnings(gpoly_out <- as.sp(sf_gpolys, drop = FALSE))
+  # expect_class(gpoly_out, 'giottoPolygon')
+  # expect_class(gpoly_out@spatVector, 'Spatial')
+  # expect_class(gpoly_out@spatVectorCentroids, 'Spatial')
+  # expect_class(gpoly_out@overlaps$rna, 'Spatial') # TODO this should be points
+})
+
+test_that('sf to stars works', {
+  stars_out <- as.stars(sf_gpoints)
+  expect_class(stars_out, 'stars')
+
+  gpoints_out <- as.stars(sf_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'stars')
+
+  gpoly_out <- as.stars(sf_gpolys, drop = FALSE)
+  expect_class(gpoly_out, 'giottoPolygon')
+  expect_class(gpoly_out@spatVector, 'stars')
+  expect_class(gpoly_out@spatVectorCentroids, 'stars')
+  expect_class(gpoly_out@overlaps$rna, 'stars')
+})
+
+# convert from stars ####
+stars_gpoints <- as.stars(terra_gpoints, drop = FALSE)
+stars_gpolys <- as.stars(terra_gpolys, drop = FALSE)
+
+test_that('stars to sf works', {
+  sf_out <- as.sf(stars_gpoints)
+  expect_class(sf_out, 'sf')
+
+  gpoints_out <- as.sf(stars_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'sf')
+
+  gpoly_out <- as.sf(stars_gpolys, drop = FALSE)
+  expect_class(gpoly_out, 'giottoPolygon')
+  expect_class(gpoly_out@spatVector, 'sf')
+  expect_class(gpoly_out@spatVectorCentroids, 'sf')
+  expect_class(gpoly_out@overlaps$rna, 'sf')
+})
+
+test_that('stars to sp works', {
+  sp_out <- as.sp(stars_gpoints)
+  expect_class(sp_out, 'Spatial')
+
+  gpoints_out <- as.sp(stars_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'Spatial')
+
+  # TODO empty geometries not supported by sp
+  # The return of overlaps info as single vertex polys needs to be fixed first.
+  # suppressWarnings(gpoly_out <- as.sp(stars_gpolys, drop = FALSE))
+  # expect_class(gpoly_out, 'giottoPolygon')
+  # expect_class(gpoly_out@spatVector, 'Spatial')
+  # expect_class(gpoly_out@spatVectorCentroids, 'Spatial')
+  # expect_class(gpoly_out@overlaps$rna, 'Spatial')
+})
+
+test_that('stars to terra works', {
+  stars_out <- as.terra(stars_gpoints)
+  expect_class(stars_out, 'SpatVector')
+
+  gpoints_out <- as.terra(stars_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'SpatVector')
+
+  gpoly_out <- as.terra(stars_gpolys, drop = FALSE)
+  expect_class(gpoly_out, 'giottoPolygon')
+  expect_class(gpoly_out@spatVector, 'SpatVector')
+  expect_class(gpoly_out@spatVectorCentroids, 'SpatVector')
+  expect_class(gpoly_out@overlaps$rna, 'SpatVector')
+})
+
+
+
+# convert from sp ####
+sp_gpoints <- as.sp(terra_gpoints, drop = FALSE)
+suppressWarnings(sp_gpolys <- as.sp(terra_gpolys, drop = FALSE))
+
+test_that('sp to sf works', {
+  sf_out <- as.sf(sp_gpoints)
+  expect_class(sf_out, 'sf')
+
+  gpoints_out <- as.sf(sp_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'sf')
+
+  gpoly_out <- as.sf(sp_gpolys, drop = FALSE)
+  expect_class(gpoly_out, 'giottoPolygon')
+  expect_class(gpoly_out@spatVector, 'sf')
+  expect_class(gpoly_out@spatVectorCentroids, 'sf')
+  expect_class(gpoly_out@overlaps$rna, 'sf')
+})
+
+test_that('sp to terra works', {
+  sp_out <- as.terra(sp_gpoints)
+  expect_class(sp_out, 'SpatVector')
+
+  gpoints_out <- as.terra(sp_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'SpatVector')
+
+  # will usually warn about few vertices in the overlaps
+  suppressWarnings(gpoly_out <- as.terra(sp_gpolys, drop = FALSE))
+  expect_class(gpoly_out, 'giottoPolygon')
+  expect_class(gpoly_out@spatVector, 'SpatVector')
+  expect_class(gpoly_out@spatVectorCentroids, 'SpatVector')
+  expect_class(gpoly_out@overlaps$rna, 'SpatVector') # TODO this should be points
+})
+
+test_that('sp to stars works', {
+  stars_out <- as.stars(sp_gpoints)
+  expect_class(stars_out, 'stars')
+
+  gpoints_out <- as.stars(sp_gpoints, drop = FALSE)
+  expect_class(gpoints_out, 'giottoPoints')
+  expect_class(gpoints_out@spatVector, 'stars')
+
+  gpoly_out <- as.stars(sp_gpolys, drop = FALSE)
+  expect_class(gpoly_out, 'giottoPolygon')
+  expect_class(gpoly_out@spatVector, 'stars')
+  expect_class(gpoly_out@spatVectorCentroids, 'stars')
+  expect_class(gpoly_out@overlaps$rna, 'stars')
+})


### PR DESCRIPTION
- Add: tests for spatial converters
- Fix: `do_gpoly()` so that it detects other spatial classes in overlaps other than `SpatVectors`
- Change: sp signature does not exist. Supposed to use Spatial

Tests are all passing other than some conversions with sp since the `giottoPolygon` object used for testing has SpatVector polygons in the overlaps, despite it being effectively points information.