### PR TITLE
Mixedsort

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     data.table (>= 1.12.2),
     dbscan (>= 1.1-3),
     deldir (>= 1.0.6),
-    GiottoUtils (>= 0.1.2),
+    GiottoUtils (>= 0.1.3),
     igraph (>= 1.2.4.1),
     magick,
     Matrix (>= 1.6.2),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,12 +2,16 @@
 
 # GiottoClass 0.1.3
 
+## bug fixes
+- fix unexpected sorting in `addCellMetadata()` [#853](https://github.com/drieslab/Giotto/issues/853) by rbutleriii
+
 ## new
 - vignette for image tools
+- `init_gobject` param in `loadGiotto()` to control whether object initialization is performed
 
 ## enhancements
 - more subobjects respond to `colnames`, `rownames`, `dimnames`
-- `plot()` and `show()` now handles 3D `spatLocsObj`
+- `plot()` and `show()` now handle 3D `spatLocsObj`
 
 # GiottoClass 0.1.2 (2024/01/02)
 

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -1135,8 +1135,8 @@ setMethod(
     mat_r_names <- rownames(overlapmatrix)
     mat_c_names <- colnames(overlapmatrix)
     overlapmatrix <- overlapmatrix[
-      match(sort(mat_r_names), mat_r_names),
-      match(sort(mat_c_names), mat_c_names)
+      match(mixedsort(mat_r_names), mat_r_names),
+      match(mixedsort(mat_c_names), mat_c_names)
     ]
 
     overlapExprObj <- create_expr_obj(
@@ -1962,7 +1962,7 @@ aggregateStacksLocations <- function(gobject,
   stack_spatvector <- terra::makeValid(stack_spatvector)
 
   # 3. aggregate individual cells/polys
-  all_poly_ids <- sort(unique(stack_spatvector$poly_ID))
+  all_poly_ids <- mixedsort(unique(stack_spatvector$poly_ID))
 
   # run in for loop if data is very very big
   if (isTRUE(for_loop)) {

--- a/R/auxilliary.R
+++ b/R/auxilliary.R
@@ -1081,7 +1081,7 @@ createMetafeats <- function(gobject,
     misc = list(expr_values_used = expression_values)
   )
 
-  if (return_gobject == TRUE) {
+  if (isTRUE(return_gobject)) {
     ## enrichment scores
     spenr_names <- list_spatial_enrichments_names(gobject = gobject, spat_unit = spat_unit, feat_type = feat_type)
 

--- a/R/classes.R
+++ b/R/classes.R
@@ -318,80 +318,6 @@ setClass("spatFeatData",
 ## Giotto class ####
 
 
-## * Check ###
-# Giotto class
-
-
-# #' @title Check Giotto Object
-# #' @name check_giottoObj
-# #' @description check function for S4 giotto object
-# #' @param object giotto object to check
-# #' @keywords internal
-# #' @noRd
-# check_giotto_obj = function(object) {
-#
-#
-#   errors = character()
-#   ch = box_chars()
-#
-#
-#   ## Validate Nesting ##
-#   ## ---------------- ##
-#
-#   slot_depths = giotto_slot_depths()
-#   for(slot_i in seq(nrow(slot_depths))) {
-#
-#     slot_data = slot(object, slot_depths$slot[[slot_i]])
-#     if(!is.null(slot_data)) {
-#       if(depth(slot_data, method = 'min') != slot_depths$depth[[slot_i]]) {
-#         msg = wrap_txt('Invalid nesting discovered for',
-#                        slot_depths$slot[[slot_i]],
-#                        'slot')
-#         errors = c(errors, msg)
-#       }
-#     }
-#   }
-
-
-
-
-# ## Match spatial units and feature types ##
-#
-# # Find existing spat_units in source data
-# uniqueSrcSU = list_expression(object)$spat_unit
-# uniqueSrcSU = unique(uniqueSrcSU, list_spatial_info_names(object))
-#
-# # Find existing feat_types in source data
-# uniqueSrcFT = list_expression(object)$feat_type
-# uniqueSrcFT = unique(uniqueSrcFT, list_feature_info_names(object))
-#
-# # Find existing spat_units and feat_types within other data slots
-# uniqueDatSU = lapply(gDataSlots, function(x) list_giotto_data(gobject = object, slot = x)$spat_unit)
-# uniqueDatFT = lapply(gDataSlots, function(x) list_giotto_data(gobject = object, slot = x)$feat_type)
-
-# # If any spat_units exist, ensure that associated objects have identical cell_IDs
-# if(length(uniqueSU) > 0) {
-#   for(SU in seq_along(uniqueSU)) {
-#
-#     all(lapply(gDataSlots, function(x) {
-#       list_giotto_data(gobject = object,
-#                        slot = x)
-#     }))
-#   }
-# }
-#
-#
-#
-#
-#
-#
-#
-#   if(length(errors) == 0) TRUE else errors
-# }
-
-
-
-
 
 
 
@@ -433,11 +359,6 @@ updateGiottoObject <- function(gobject) {
     gobject@largeImages <- lapply(gobject@largeImages, .update_giotto_image)
   }
 
-  # # 3.3.X release adds mirai slot
-  # if (is.null(attr(gobject, "mirai"))) {
-  #   attr(gobject, "mirai") <- list()
-  # }
-
   return(gobject)
 }
 
@@ -448,10 +369,12 @@ updateGiottoObject <- function(gobject) {
 # ! Any slot modifications should also be reflected in packedGiotto class !
 
 #' @title S4 giotto Class
-#' @description Framework of giotto object to store and work with spatial expression data
+#' @description \pkg{Giotto}'s core object that encapsulates all the components
+#' of a spatial-omic project and facilitates analyses.
 #' @concept giotto object
 #' @slot expression expression information
-#' @slot expression_feat available features (e.g. rna, protein, ...)
+#' @slot expression_feat The different features or modalities such as rna,
+#' protein, metabolites, ... that are provided in the expression slot.
 #' @slot spatial_locs spatial location coordinates for cells/spots/grids
 #' @slot spatial_info information about spatial units (Giotto spatVector)
 #' @slot cell_metadata metadata for cells
@@ -473,13 +396,26 @@ updateGiottoObject <- function(gobject) {
 #' @slot join_info information about joined Giotto objects
 #' @slot multiomics multiomics integration results
 #' @slot h5_file path to h5 file
-# #' @slot mirai unresolved mirai values pool
 #' @details
-#' \[\strong{expression}\] There are several ways to provide expression information:
 #'
-#' \[\strong{expression_feat}\] The different features or modalities such as rna, protein, metabolites, ...
-#' that are provided in the expression slot.
-#'
+#' \[**initialize**\]
+#' The `giotto` class has a robust `initialize()` method that is automatically
+#' called upon setting data into the object, updates of the `giottoInstructions`,
+#' and loading of saved objects. It performs the following steps:
+#' 1. Update the object and subobjects for class definition changes if needed
+#' 2. Ensure a set of `giottoInstructions` are available, otherwise generate defaults
+#' 3. Ensure a giotto python environment is accessible when the options
+#'    giotto.has_conda and giotto.use_conda are TRUE
+#' 4. Check the active spat_unit and feat_type
+#' 5. Ensure spatial/cell ID consistency and initialize the cell_ID and feat_ID
+#'    slots for the active spat_unit and feat_type, as well as cell and feature
+#'    metadata if they do not exist. Values for IDs and metadata are pulled
+#'    from any existing data in spatial_info/feat_info or expression slots,
+#'    with a preference for the latter.
+#' 6. Perform slot-specific and hierarchical checks that ensure dependent pieces
+#'    of information are only added AFTER the data that they depend on and that
+#'    existing information is consistent across slots.
+#' 7. Object validity checking
 #'
 #' @export giotto
 #' @exportClass giotto

--- a/R/join.R
+++ b/R/join.R
@@ -13,7 +13,7 @@
   }
 
   final_feats <- unique(unlist(final_feats))
-  final_feats <- sort(final_feats)
+  final_feats <- mixedsort(final_feats)
 
 
 

--- a/R/methods-IDs.R
+++ b/R/methods-IDs.R
@@ -5,7 +5,21 @@ NULL
 #' @title Spatial and feature IDs
 #' @name spatIDs-generic
 #' @description Get the cell IDs (termed spatial IDs to better reflect when not at
-#' the single-cell level) and feature IDs of a giotto object or subobject
+#' the single-cell level) and feature IDs of a giotto object or subobject.
+#'
+#' \[**`giotto` object specific**\]
+#' When applied on a `giotto` object, these functions pull from the `cell_ID` and
+#' `feat_ID` slots. The values within these slots are updated whenever the object
+#' is data is changed and, importantly, whenever the active spat_unit and
+#' feat_type is set (see [activeSpatUnit()] and [activeFeatType()]). New values
+#' for these slots are specific to the active spat_unit and feat_type and are
+#' detected from either the *subcellular* level (`giottoPolygon` and `giottoPoints`)
+#' or the *aggregate* level (expression matrix) data, with a preference for the
+#' latter if it exists.
+#' Be aware that with this current behavior, values returned by`spatIDs()` and
+#' `featIDs()` should be regarded as the minimal set of expected IDs within
+#' all `giotto` slots, and not always the exact set or ordering.
+#'
 #' @aliases spatIDs featIDs
 #' @param x an object
 #' @param ... additional parameters to pass

--- a/R/methods-initialize.R
+++ b/R/methods-initialize.R
@@ -8,6 +8,7 @@ NULL
 
 
 # giotto ####
+# See documentation in classes.R
 #' @noRd
 #' @keywords internal
 setMethod("initialize", signature("giotto"), function(.Object, ...) {
@@ -34,8 +35,6 @@ setMethod("initialize", signature("giotto"), function(.Object, ...) {
 
 
 
-
-  # message('initialize Giotto run\n\n')  # debug
 
 
   ## set instructions ##
@@ -360,6 +359,9 @@ setMethod("initialize", signature("giotto"), function(.Object, ...) {
   ## Metadata ##
   ## ------------- ##
 
+  # spat_unit cross compatibility for metadata checks use spatIDs() to pull
+  # the relevant set of spatIDs for that spatial unit.
+
   if (!is.null(avail_cm)) {
     .check_cell_metadata(gobject = .Object) # modifies by reference
   }
@@ -372,7 +374,7 @@ setMethod("initialize", signature("giotto"), function(.Object, ...) {
   ## Spatial locations ##
   ## ----------------- ##
 
-  if (!is.null(avail_expr) & !is.null(avail_sl)) {
+  if (!is.null(avail_expr) && !is.null(avail_sl)) {
     # 1. ensure spatial locations and expression matrices have the same cell IDs
     # 2. give cell IDs if not provided
     .check_spatial_location_data(gobject = .Object) # modifies by reference
@@ -383,7 +385,7 @@ setMethod("initialize", signature("giotto"), function(.Object, ...) {
   ## Spatial network ##
   ## --------------- ##
 
-  if (!is.null(avail_sl) & !is.null(avail_sn)) {
+  if (!is.null(avail_sl) && !is.null(avail_sn)) {
     # 1. ensure vertices have same IDs as seen in spat_unit for gobject
     # 2. ensure spatial locations of same spat_unit exists
     .check_spatial_networks(gobject = .Object)
@@ -394,7 +396,7 @@ setMethod("initialize", signature("giotto"), function(.Object, ...) {
   ## Spatial enrichment ##
   ## ------------------ ##
 
-  if (!is.null(avail_sl) & !is.null(avail_se)) {
+  if (!is.null(avail_sl) && !is.null(avail_se)) {
     # 1. ensure IDs in enrichment match gobject for same spat_unit
     # 2. ensure spatial locations exist for same spat_unit
     .check_spatial_enrichment(gobject = .Object)
@@ -405,7 +407,7 @@ setMethod("initialize", signature("giotto"), function(.Object, ...) {
   ## Nearest networks ##
   ## ---------------- ##
 
-  if (!is.null(avail_expr) & !is.null(avail_nn)) {
+  if (!is.null(avail_expr) && !is.null(avail_nn)) {
     .check_nearest_networks(gobject = .Object)
   }
 

--- a/R/methods-rbind.R
+++ b/R/methods-rbind.R
@@ -24,7 +24,7 @@ setMethod(
     poly_names <- c(slot(x, "name"), slot(y, "name"))
     homo <- identical(poly_names[[1L]], poly_names[[2L]])
     if (!isTRUE(homo)) {
-      new_name <- paste0(sort(poly_names), collapse = "-")
+      new_name <- paste0(mixedsort(poly_names), collapse = "-")
       return(rbind2_giotto_polygon_hetero(x = x, y = y, new_name = new_name, add_list_ID = add_list_ID))
     } else {
       return(rbind2_giotto_polygon_homo(x = x, y = y))

--- a/R/slot_accessors.R
+++ b/R/slot_accessors.R
@@ -288,19 +288,6 @@ set_cell_id <- function(gobject,
         set_defaults = TRUE
       ))
 
-
-      # IDs = lapply(seq(nrow(expr_avail)), function(expr_i) {
-      #   ex_ID = spatIDs(
-      #     get_expression_values(
-      #       gobject = gobject,
-      #       spat_unit = spat_unit,
-      #       feat_type = expr_avail$feat_type[[expr_i]],
-      #       values = expr_avail$name[[expr_i]],
-      #       output = 'exprObj'
-      #     )
-      #   )
-      # })
-      # cell_IDs = unique(unlist(IDs))
     } else if (spat_unit %in% si_avail$spat_info) { # fallback to spat_info
 
       cell_IDs <- spatIDs(get_polygon_info(

--- a/R/slot_check.R
+++ b/R/slot_check.R
@@ -13,7 +13,9 @@
   used_su <- unique(avail_cm$spat_unit)
 
 
-  # check hierarchical
+  # [check hierarchical]
+  # metadata is only allowed to exist when the associated spat_unit exists in
+  # polygon and/or expression data
   missing_su <- !used_su %in% g_su
   if (any(missing_su)) {
     stop(wrap_txt("No expression or polygon information discovered for spat_unit:",

--- a/man/addFeatMetadata.Rd
+++ b/man/addFeatMetadata.Rd
@@ -9,9 +9,9 @@ addFeatMetadata(
   feat_type = NULL,
   spat_unit = NULL,
   new_metadata,
-  by_column = F,
-  column_feat_ID = NULL,
-  vector_name = NULL
+  vector_name = NULL,
+  by_column = FALSE,
+  column_feat_ID = NULL
 )
 }
 \arguments{
@@ -23,11 +23,11 @@ addFeatMetadata(
 
 \item{new_metadata}{new metadata to use)}
 
+\item{vector_name}{(optional) custom name if you provide a single vector}
+
 \item{by_column}{merge metadata based on \emph{feat_ID} column in \code{\link{fDataDT}}}
 
 \item{column_feat_ID}{column name of new metadata to use if by_column = TRUE}
-
-\item{vector_name}{(optional) custom name if you provide a single vector}
 }
 \value{
 giotto object

--- a/man/giotto-class.Rd
+++ b/man/giotto-class.Rd
@@ -6,20 +6,38 @@
 \alias{giotto}
 \title{S4 giotto Class}
 \description{
-Framework of giotto object to store and work with spatial expression data
+\pkg{Giotto}'s core object that encapsulates all the components
+of a spatial-omic project and facilitates analyses.
 }
 \details{
-[\strong{expression}] There are several ways to provide expression information:
-
-[\strong{expression_feat}] The different features or modalities such as rna, protein, metabolites, ...
-that are provided in the expression slot.
+[\strong{initialize}]
+The \code{giotto} class has a robust \code{initialize()} method that is automatically
+called upon setting data into the object, updates of the \code{giottoInstructions},
+and loading of saved objects. It performs the following steps:
+\enumerate{
+\item Update the object and subobjects for class definition changes if needed
+\item Ensure a set of \code{giottoInstructions} are available, otherwise generate defaults
+\item Ensure a giotto python environment is accessible when the options
+giotto.has_conda and giotto.use_conda are TRUE
+\item Check the active spat_unit and feat_type
+\item Ensure spatial/cell ID consistency and initialize the cell_ID and feat_ID
+slots for the active spat_unit and feat_type, as well as cell and feature
+metadata if they do not exist. Values for IDs and metadata are pulled
+from any existing data in spatial_info/feat_info or expression slots,
+with a preference for the latter.
+\item Perform slot-specific and hierarchical checks that ensure dependent pieces
+of information are only added AFTER the data that they depend on and that
+existing information is consistent across slots.
+\item Object validity checking
+}
 }
 \section{Slots}{
 
 \describe{
 \item{\code{expression}}{expression information}
 
-\item{\code{expression_feat}}{available features (e.g. rna, protein, ...)}
+\item{\code{expression_feat}}{The different features or modalities such as rna,
+protein, metabolites, ... that are provided in the expression slot.}
 
 \item{\code{spatial_locs}}{spatial location coordinates for cells/spots/grids}
 

--- a/man/loadGiotto.Rd
+++ b/man/loadGiotto.Rd
@@ -9,6 +9,7 @@ loadGiotto(
   load_params = list(),
   reconnect_giottoImage = TRUE,
   python_path = NULL,
+  init_gobject = TRUE,
   verbose = TRUE
 )
 }
@@ -20,6 +21,9 @@ loadGiotto(
 \item{reconnect_giottoImage}{(default = TRUE) whether to attempt reconnection of magick based image objects}
 
 \item{python_path}{(optional) manually set your python path}
+
+\item{init_gobject}{logical. Whether to initialize the \code{giotto} object after
+loading. (default = TRUE)}
 
 \item{verbose}{be verbose}
 }

--- a/man/spatIDs-generic.Rd
+++ b/man/spatIDs-generic.Rd
@@ -63,5 +63,18 @@
 }
 \description{
 Get the cell IDs (termed spatial IDs to better reflect when not at
-the single-cell level) and feature IDs of a giotto object or subobject
+the single-cell level) and feature IDs of a giotto object or subobject.
+
+[\strong{\code{giotto} object specific}]
+When applied on a \code{giotto} object, these functions pull from the \code{cell_ID} and
+\code{feat_ID} slots. The values within these slots are updated whenever the object
+is data is changed and, importantly, whenever the active spat_unit and
+feat_type is set (see \code{\link[=activeSpatUnit]{activeSpatUnit()}} and \code{\link[=activeFeatType]{activeFeatType()}}). New values
+for these slots are specific to the active spat_unit and feat_type and are
+detected from either the \emph{subcellular} level (\code{giottoPolygon} and \code{giottoPoints})
+or the \emph{aggregate} level (expression matrix) data, with a preference for the
+latter if it exists.
+Be aware that with this current behavior, values returned by\code{spatIDs()} and
+\code{featIDs()} should be regarded as the minimal set of expected IDs within
+all \code{giotto} slots, and not always the exact set or ordering.
 }


### PR DESCRIPTION
- fix unexpected sorting in `addCellMetadata()` and `addFeatMetadata()` [#853](https://github.com/drieslab/Giotto/issues/853) by rbutleriii
  - Ordering at start of call is now matched against when returning.
  - testing updated to expect this behavior.
- `gtools::mixedsort()` is now used whenever sorting on IDs [#853](https://github.com/drieslab/Giotto/issues/853) by rbutleriii

- bump *GiottoUtils* version requirement
- documentation
  