### PR TITLE
hotfix: unused param in `.subset_expression_data()`

### DIFF
--- a/.github/workflows/covr.yml
+++ b/.github/workflows/covr.yml
@@ -27,6 +27,14 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: Set up dependencies (GiottoData)
+        run: |
+          suppressWarnings({
+            install.package("remotes")
+            remotes::install_github("drieslab/GiottoData", build = FALSE)
+          })
+        shell: Rscript {0}
+
       - name: Set up dependencies (general)
         uses: r-lib/actions/setup-r-dependencies@v2
         env:
@@ -34,7 +42,7 @@ jobs:
           _R_CHECK_RD_XREFS: false
         with:
           dependencies: '"hard"' # do not use suggested dependencies
-          extra-packages: github::drieslab/GiottoData, any::rcmdcheck, any::testthat, any::rlang, any::R.utils, any::sp, any::stars, any::raster, any::sf, any::RTriangle, any::geometry, any::remotes, any::covr
+          extra-packages: any::rcmdcheck, any::testthat, any::rlang, any::R.utils, any::sp, any::stars, any::raster, any::sf, any::RTriangle, any::geometry, any::covr
           needs: coverage
 
       - name: Generate coverage report

--- a/.github/workflows/covr.yml
+++ b/.github/workflows/covr.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up dependencies (GiottoData)
         run: |
           suppressWarnings({
-            install.package("remotes")
+            install.packages("remotes")
             remotes::install_github("drieslab/GiottoData", build = FALSE)
           })
         shell: Rscript {0}

--- a/.github/workflows/covr.yml
+++ b/.github/workflows/covr.yml
@@ -34,7 +34,7 @@ jobs:
           _R_CHECK_RD_XREFS: false
         with:
           dependencies: '"hard"' # do not use suggested dependencies
-          extra-packages: github::drieslab/GiottoData, any::rcmdcheck, any::testthat, any::rlang, any::R.utils, any::remotes, any::covr,  any::sp, any::stars, any::raster, any::sf,  any::RTriangle, any::geometry
+          extra-packages: github::drieslab/GiottoData, any::rcmdcheck, any::testthat, any::rlang, any::R.utils, any::sp, any::stars, any::raster, any::sf, any::RTriangle, any::geometry, any::remotes, any::covr
           needs: coverage
 
       - name: Generate coverage report

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GiottoClass
 Title: Giotto Suite object definitions and framework
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(
 	person("Ruben", "Dries", email = "rubendries@gmail.com",
 		 role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
 
-# GiottoClass 0.2.0
+
+# GiottoClass 0.2.1 (2024/02/28)
 
 ## breaking changes
 - `giotto` slot `versions` supercedes `OS_platform`. Used for tracking GiottoClass version.
 
 ## bug fixes
+- fix `subsetGiotto` unused `on` argument
 - fix `giotto` object saving when image intensities overlaps data are present.
 - fix `exprObj` `show()` for small matrices
 - fix `giotto` `calculateOverlap()` method when working with image intensities data.

--- a/R/subset.R
+++ b/R/subset.R
@@ -63,7 +63,7 @@
     avail_cex[, subset_cells := TRUE]
     avail_fex[, subset_feats := TRUE]
     avail_ex <- merge(avail_cex, avail_fex,
-      on = c("spat_unit", "feat_type", "name"),
+      by = c("spat_unit", "feat_type", "name"),
       all = TRUE
     )
   }


### PR DESCRIPTION
- The cols to merge on was erroneously passed to a nonexistent `on` param instead of `by` param for `merge.data.table()`.  
  - This particular error should not impact analysis since merging on all shared columns is already the default behavior for _data.table_.