### PR TITLE
fix: `loadGiotto()` when similar spat_unit or feat_type is exists in the same object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Description: This package contains the Giotto object and subobject class
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Depends:
     base (>= 4.4.0),
     utils (>= 4.4.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     data.table (>= 1.12.2),
     dbscan (>= 1.1-3),
     deldir (>= 1.0.6),
-    GiottoUtils (>= 0.1.7),
+    GiottoUtils (>= 0.1.10),
     graphics,
     grDevices,
     igraph (>= 1.2.4.1),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 - python environment installation and how it relates to default settings such as .condarc may have changed.
 - `giottoImage` `name` slot now requires `character` and will not accept `NULL`
 
+## bug fixes
+- `loadGiotto()` no longer errors with similarly named spat_units or feat_types (e.g. "cell" and "new_cell" would previously throw an error)
+
 ## enhancements
 - `verbose` param for `createNearestNetwork()`
 - `checkGiottoEnvironment()` in addition to full filepaths, also now supports name of environment or installation directory

--- a/R/save_load.R
+++ b/R/save_load.R
@@ -271,6 +271,7 @@ saveGiotto <- function(
 }
 
 
+
 #' @title loadGiotto
 #' @name loadGiotto
 #' @description Saves a Giotto object to a specific folder structure
@@ -307,301 +308,49 @@ loadGiotto <- function(path_to_folder,
     img_type <- NULL
 
     path_to_folder <- path.expand(path_to_folder)
+    vmsg(.v = verbose, .is_debug = TRUE, "load from:", path_to_folder)
 
     if (!file.exists(path_to_folder)) {
         stop("path_to_folder does not exist \n")
     }
 
     ## 1. load giotto object
-    vmsg(.v = verbose, "1. read Giotto object")
-
-    gobject_file <- list.files(path_to_folder, pattern = "gobject")
-
-    if (identical(gobject_file, character(0))) {
-        vmsg(.v = verbose, "giotto object was not found
-         skip loading giotto object")
-    } else if (length(gobject_file) > 1) {
-        vmsg(.v = verbose, "more than 1 giotto object was found
-         skip loading giotto object")
-    } else {
-        if (grepl(".RDS", x = gobject_file)) {
-            gobject <- do.call(
-                "readRDS",
-                c(
-                    file = paste0(path_to_folder, "/", "gobject.RDS"),
-                    load_params
-                )
-            )
-        }
-
-        if (grepl(".qs", x = gobject_file)) {
-            package_check(pkg_name = "qs", repository = "CRAN")
-            qread_fun <- get("qread", asNamespace("qs"))
-            gobject <- do.call(
-                qread_fun,
-                c(
-                    file = paste0(path_to_folder, "/", "gobject.qs"),
-                    load_params
-                )
-            )
-        }
-    }
-
-
-
-
-
-
-    ## 2. read in features
-    vmsg(.v = verbose, "2. read Giotto feature information")
-    feat_files <- list.files(
-        path = paste0(path_to_folder, "/Features"),
-        pattern = ".shp"
+    gobject <- .load_gobject_core(
+        path_to_folder = path_to_folder,
+        load_params = load_params,
+        verbose = verbose
     )
+    
+    ### ### spatial information loading ### ###
+    # terra vector objects are serialized as .shp files.
+    # These .shp files have to be read back in and then the relevant objects
+    # in the giotto object need to be regenerated.
 
-    if (length(feat_files) != 0) {
-        feat_names <- gsub(feat_files,
-            pattern = "_feature_spatVector.shp",
-            replacement = ""
-        )
-        feat_paths <- list.files(
-            path = paste0(path_to_folder, "/Features"),
-            pattern = ".shp", full.names = TRUE
-        )
-
-        vector_names_paths <- list.files(
-            path = paste0(path_to_folder, "/Features"), pattern = ".txt",
-            full.names = TRUE
-        )
-
-        for (feat_i in seq_len(length(feat_names))) {
-            if (verbose) wrap_msg(feat_paths[feat_i])
-            spatVector <- terra::vect(x = feat_paths[feat_i])
-
-            # read in original column names and assign to spatVector
-            spatVector_names <- fread(
-                input = vector_names_paths[feat_i],
-                header = FALSE
-            )[["V1"]]
-            names(spatVector) <- spatVector_names
-
-            feat_name <- feat_names[feat_i]
-            if (verbose) wrap_msg(feat_name)
-            gobject@feat_info[[feat_name]]@spatVector <- spatVector
-        }
-    }
+    ## 2. read in spatial features
+    gobject <- .load_giotto_feature_info(
+        gobject = gobject,
+        path_to_folder = path_to_folder, 
+        verbose = verbose
+    )
 
 
     ## 3. read in spatial polygons
-    vmsg(.v = verbose, "3. read Giotto spatial information")
-
-    spat_paths <- list.files(
-        path = paste0(path_to_folder, "/SpatialInfo"),
-        pattern = "spatVector.shp",
-        full.names = TRUE
+    gobject <- .load_giotto_spatial_info(
+        gobject = gobject,
+        path_to_folder = path_to_folder,
+        verbose = verbose
     )
-    spat_files <- basename(spat_paths)
-
-    vector_names_paths <- list.files(
-        path = paste0(path_to_folder, "/SpatialInfo"),
-        pattern = "spatVector_names.txt",
-        full.names = TRUE
-    )
-
-    if (length(spat_files) != 0) {
-        ## 3.1. shapes
-        if (isTRUE(verbose)) {
-            wrap_msg("3.1 read Giotto spatial shape information")
-            wrap_msg(spat_files)
-        }
-
-        spat_names <- gsub(spat_files,
-            pattern = "_spatInfo_spatVector.shp",
-            replacement = ""
-        )
-
-        for (spat_i in seq_len(length(spat_names))) {
-            spatVector <- terra::vect(x = spat_paths[spat_i])
-
-            # read in original column names and assign to spatVector
-            spatVector_names <- fread(
-                input = vector_names_paths[spat_i],
-                header = FALSE
-            )[["V1"]]
-            names(spatVector) <- spatVector_names
-
-            spat_name <- spat_names[spat_i]
-            if (isTRUE(verbose)) message(spat_name)
-            gobject@spatial_info[[spat_name]]@spatVector <- spatVector
-        }
-
-        ## 3.2. centroids
-        if (isTRUE(verbose)) {
-            wrap_msg("\n 3.2 read Giotto spatial centroid information \n")
-        }
-
-        centroid_search_term <- gsub(spat_files,
-            pattern = "_spatInfo_spatVector.shp",
-            replacement = "_spatInfo_spatVectorCentroids.shp"
-        )
-        centroid_paths <- vapply(
-            centroid_search_term,
-            function(gp_centroid) {
-                list.files(
-                    path = paste0(path_to_folder, "/SpatialInfo"),
-                    pattern = gp_centroid, full.names = TRUE
-                )
-            },
-            FUN.VALUE = character(1L),
-            USE.NAMES = FALSE)
-
-        # check if centroid are provided for spatvector polygons
-        test_missing <- unlist(lapply(centroid_paths,
-            FUN = function(x) identical(x, character(0))
-        ))
-        centroid_paths <- centroid_paths[!test_missing]
-
-        if (length(centroid_paths) == 0) {
-            if (verbose) {
-                wrap_msg("No centroids were found, centroid loading will be
-                        skipped \n")
-            }
-        } else {
-            centroid_files <- basename(centroid_paths)
-
-            if (length(centroid_files != 0)) {
-                spat_names <- gsub(centroid_files,
-                    pattern = "_spatInfo_spatVectorCentroids.shp",
-                    replacement = ""
-                )
-
-                vector_names_paths <- list.files(
-                    path = paste0(path_to_folder, "/SpatialInfo"),
-                    pattern = "spatVectorCentroids_names.txt",
-                    full.names = TRUE
-                )
-
-                for (spat_i in seq_len(length(spat_names))) {
-                    spatVector <- terra::vect(x = centroid_paths[spat_i])
-
-                    # read in original column names and assign to spatVector
-                    spatVector_names <- fread(
-                        input = vector_names_paths[spat_i],
-                        header = FALSE
-                    )[["V1"]]
-                    names(spatVector) <- spatVector_names
-
-                    spat_name <- spat_names[spat_i]
-                    if (isTRUE(verbose)) message(spat_name)
-                    gobject@spatial_info[[spat_name]]@spatVectorCentroids <-
-                        spatVector
-                }
-            }
-        }
-
-
-        ## 3.3. overlaps
-        if (isTRUE(verbose)) {
-            wrap_msg("\n3.3 read Giotto spatial overlap information \n")
-        }
-
-        overlap_search_term <- gsub(spat_files,
-            pattern = "_spatInfo_spatVector.shp",
-            replacement = "_spatInfo_spatVectorOverlaps.shp"
-        )
-        overlap_files <- list.files(
-            path = paste0(path_to_folder, "/SpatialInfo"),
-            pattern = "spatVectorOverlaps.shp"
-        )
-
-        # check if overlap information is available
-        if (length(overlap_files) == 0) {
-            if (verbose) {
-                wrap_msg("No overlaps were found, overlap loading will be
-                        skipped")
-            }
-        } else {
-            wrap_msg(overlap_files)
-
-            # find overlaps per spatVector
-            for (sv_i in seq_along(overlap_search_term)) {
-                overlap_paths <- list.files(
-                    path = paste0(path_to_folder, "/SpatialInfo"),
-                    pattern = overlap_search_term[sv_i], full.names = TRUE
-                )
-                overlap_filenames <- basename(overlap_paths)
-
-                # get matching names files for the spatVector.shp files
-                overlap_column_names <- gsub(overlap_filenames,
-                    pattern = "spatVectorOverlaps.shp",
-                    replacement = "spatVectorOverlaps_names.txt"
-                )
-                overlap_paths_colnames <- paste0(
-                    dirname(overlap_paths), "/",
-                    overlap_column_names
-                )
-
-                for (spat_i in seq_along(overlap_filenames)) {
-                    spatVector <- terra::vect(x = overlap_paths[spat_i])
-
-                    # read in original column names and assign to spatVector
-                    spatVector_names <- fread(
-                        input = overlap_paths_colnames[spat_i],
-                        header = FALSE
-                    )[["V1"]]
-                    if (verbose) wrap_msg(spatVector_names)
-                    names(spatVector) <- spatVector_names
-
-                    feat_name <- gsub(overlap_filenames[spat_i],
-                        pattern = paste0("_", overlap_search_term[sv_i]),
-                        replacement = ""
-                    )
-                    spat_name <- gsub(overlap_filenames[spat_i],
-                        pattern = paste0(feat_name, "_"),
-                        replacement = ""
-                    )
-                    spat_name <- gsub(spat_name,
-                        pattern = "_spatInfo_spatVectorOverlaps.shp",
-                        replacement = ""
-                    )
-
-                    if (isTRUE(verbose)) wrap_msg(spat_name, " and ", feat_name)
-                    gobject@spatial_info[[spat_name]]@overlaps[[feat_name]] <-
-                        spatVector
-                }
-            }
-        }
-    }
-
-
 
 
     ## 4. images
-    vmsg(.v = verbose, "\n4. read Giotto image information")
-
     # compatibility for pre-v0.3.0
     gobject <- .update_image_slot(gobject)
-
-    image_files <- list.files(path = paste0(path_to_folder, "/Images"))
-    if (length(image_files) != 0) {
-        image_names <- unique(gsub(image_files,
-            pattern = "_spatRaster.*",
-            replacement = ""
-        ))
-        for (image_i in seq_len(length(image_names))) {
-            image_name <- image_names[image_i]
-            if (verbose) image_name
-            new_path <- paste0(
-                path_to_folder, "/Images", "/", image_name,
-                "_spatRaster"
-            )
-            spatRaster <- terra::rast(x = new_path)
-
-            gobject@images[[image_name]]@raster_object <- spatRaster
-            gobject@images[[image_name]]@file_path <- new_path
-        }
-    }
-
+    gobject <- .load_giotto_images(
+        gobject = gobject,
+        path_to_folder = path_to_folder,
+        verbose = verbose
+    )
+    
     if (isTRUE(reconnect_giottoImage)) {
         if (!is.null(list_images(gobject))) {
             if (list_images(gobject)[img_type == "image", .N] > 0) {
@@ -644,3 +393,327 @@ loadGiotto <- function(path_to_folder,
 
     return(gobject)
 }
+
+# internals ####
+
+
+# load in the gobject S4 object.
+# the contained point-based information will need to be regenerated/reconnected
+# returns either a gobject or nothing if the file is missing or errors
+.load_gobject_core <- function(
+        path_to_folder, load_params, verbose = NULL
+) {
+    vmsg(.v = verbose, "1. read Giotto object")
+    
+    # gobject is expected to be saved with a filename like gobject.[ext]
+    # This item is the main S4 structure.
+    gobject_file <- list.files(path_to_folder, pattern = "gobject")
+    
+    if (identical(gobject_file, character(0))) { # no matches
+        vmsg(.v = verbose, "giotto object was not found
+         skip loading giotto object")
+    } else if (length(gobject_file) > 1) { # more than one match
+        vmsg(.v = verbose, "more than 1 giotto object was found
+         skip loading giotto object")
+    } else {
+        
+        # pick a reading function
+        read_fun <- NULL
+        if (grepl(".RDS", x = gobject_file)) { # .RDS file
+            read_fun <- "readRDS"
+            full_path <- file.path(path_to_folder, "gobject.RDS")
+        }
+        if (grepl(".qs", x = gobject_file)) { # .qs file
+            package_check(pkg_name = "qs", repository = "CRAN")
+            read_fun <- get("qread", asNamespace("qs"))
+            full_path <- file.path(path_to_folder, "gobject.qs")
+        }
+        
+        if (is.null(read_fun)) { # unrecognized file
+            stop("object is not a recognized save format.\n ",
+                 ".RDS, .qs are supported\n")
+        }
+        
+        # read in the object
+        gobject <- do.call(
+            read_fun, args = c(file = full_path, load_params)
+        )
+        return(gobject)
+    }
+}
+
+# load and append spatial feature information
+.load_giotto_feature_info <- function(
+        gobject, path_to_folder, verbose = NULL
+) {
+    vmsg(.v = verbose, "2. read Giotto feature information")
+    vmsg(.v = verbose, .is_debug = TRUE, .initial = " ", 
+         box_chars()$l, "subdir: /Features/", sep = "")
+    
+    feats_dir <- file.path(path_to_folder, "Features")
+    manifest <- dir_manifest(feats_dir)
+    basenames <- names(manifest)
+    
+    # basenames of .shp files to load
+    shp_files <- basenames[grepl(".shp", basenames)]
+    
+    # return early if none, also catches when dir does not exist
+    if (length(shp_files) == 0) return(gobject)
+    
+    # parse the feature type(s) to load from the .shp basenames
+    feats <- gsub(shp_files, 
+        pattern = "_feature_spatVector.shp", replacement = ""
+    )
+    
+    # basenames of .txt files to load
+    # These have attribute info names (e.g. feat_ID, feat_ID_uniq)
+    # this is done since serialized SpatVectors may have clipped names.
+    txt_files <- paste0(feats, "_feature_spatVector_names.txt")
+    
+    # ordering of files follow feats.
+    # Apply name to make indexing simple and unique
+    names(shp_files) <- names(txt_files) <- feats
+    
+    # iterate through features discovered and load/regenerate each
+    # then append the information to the gobject
+    for (feat in feats) {
+        load_shp <- manifest[[shp_files[[feat]]]]
+        load_txt <- manifest[[txt_files[[feat]]]]
+
+        vmsg(.v = verbose, .is_debug = TRUE, .initial = "  ",
+             sprintf("[%s] %s", feat, basename(load_shp)))
+        spatVector <- terra::vect(x = load_shp)
+        
+        # read in original column names and assign to SpatVector
+        spatVector_names <- data.table::fread(
+            input = load_txt, header = FALSE
+        )[["V1"]]
+        names(spatVector) <- spatVector_names
+        
+        gobject@feat_info[[feat]]@spatVector <- spatVector
+    }
+
+    return(gobject)
+}
+
+# load and append to gobject the spatial polygon information
+.load_giotto_spatial_info <- function(
+        gobject, path_to_folder, verbose = NULL
+) {
+    vmsg(.v = verbose, "3. read Giotto spatial information")
+    vmsg(.v = verbose, .is_debug = TRUE, .initial = " ",
+         box_chars()$l, "subdir: /SpatialInfo/", sep = "")
+    
+    spat_dir <- file.path(path_to_folder, "SpatialInfo")
+    manifest <- dir_manifest(spat_dir)
+    basenames <- names(manifest)
+    
+    # basenames of .shp files to load
+    # there are other .shp files for centroids and overlaps in this dir
+    # so the search term is more specific
+    shp_files <- basenames[grepl("spatVector.shp", basenames)]
+    
+    # return early if none, also catches when dir does not exist
+    if (length(shp_files) == 0) return(gobject) 
+    
+    ## 3.1. shapes
+    vmsg(.v = verbose, "3.1 read Giotto spatial shape information")
+    
+    # parse the spatial unit(s) to load from the .shp basenames
+    spats <- gsub(shp_files,
+        pattern = "_spatInfo_spatVector.shp", replacement = "" 
+    )
+    
+    # basenames of .txt files to load
+    # .shp files may clip these normally, so we load them separately
+    txt_files <- paste0(spats, "_spatInfo_spatVector_names.txt")
+    
+    # ordering of files follow spats.
+    # Apply name to make indexing simple and unique
+    names(shp_files) <- names(txt_files) <- spats
+
+    # iterate through spat units discovered and load/regen each
+    # then append the info to the gobject
+    for (spat in spats) {
+        load_shp <- manifest[[shp_files[[spat]]]]
+        load_txt <- manifest[[txt_files[[spat]]]]
+        
+        vmsg(.v = verbose, .is_debug = TRUE, .initial = "  ",
+             sprintf("[%s] %s", spat, basename(load_shp)))
+        spatVector <- terra::vect(x = load_shp)
+        
+        # read in original column names and assign to spatVector
+        spatVector_names <- data.table::fread(
+            input = load_txt, header = FALSE
+        )[["V1"]]
+        names(spatVector) <- spatVector_names
+        
+        gobject@spatial_info[[spat]]@spatVector <- spatVector
+    }
+    
+
+    # load centroids of gpoly
+    gobject <- .load_giotto_spatial_info_centroids(
+        gobject = gobject,
+        manifest = manifest,
+        basenames = basenames,
+        spats = spats,
+        verbose = verbose
+    )
+    
+    # load overlaps of gpoly
+    gobject <- .load_giotto_spatial_info_overlaps(
+        gobject = gobject,
+        manifest = manifest,
+        verbose = verbose
+    )
+    
+    return(gobject)
+}
+
+# load and append to gobject the polygons centroids information
+.load_giotto_spatial_info_centroids <- function(
+        gobject, manifest, basenames, spats, verbose = NULL
+) {
+    ## 3.2. centroids
+    vmsg(.v = verbose, "3.2 read Giotto spatial centroid information \n")
+    
+    # these files are optional, depending on if they have been calculated.
+    # They may not exist
+    
+    shp_search <- paste0(spats, "_spatInfo_spatVectorCentroids.shp")
+    shp_files <- basenames[basenames %in% shp_search]
+    
+    # return early if none exist
+    if (length(shp_files) == 0) return(gobject)
+    
+    txt_files <- paste0(spats, "_spatInfo_spatVectorCentroids_names.txt")
+    
+    # ordering of files follow spats
+    # apply name for simple and unique indexing
+    names(shp_files) <- names(txt_files) <- spats
+    
+    # iterate through spat_units and load/regen then append the data
+    # to the gobject
+    for (spat in spats) {
+        load_shp <- manifest[[shp_files[[spat]]]]
+        load_txt <- manifest[[txt_files[[spat]]]]
+        
+        if (is.null(load_shp)) next # skip to next spat_unit if none
+        vmsg(.v = verbose, .is_debug = TRUE, .initial = "  ",
+             sprintf("[%s] %s", spat, basename(load_shp)))
+        spatVector <- terra::vect(load_shp)
+        
+        # read in original column names and assign to spatVector
+        spatVector_names <- data.table::fread(
+            input = load_txt, header = FALSE
+        )[["V1"]]
+        names(spatVector) <- spatVector_names
+        
+        gobject@spatial_info[[spat]]@spatVectorCentroids <- spatVector
+    }
+    return(gobject)
+}
+
+# load and append to gobject the polygons overlaps information
+.load_giotto_spatial_info_overlaps <- function(
+        gobject, manifest, verbose = NULL
+) {
+    ## 3.3. overlaps
+    vmsg(.v = verbose, "3.3 read Giotto spatial overlap information \n")
+    
+    si <- get_polygon_info_list(gobject) # none case taken care of in 3.1
+    spats <- names(si)
+    
+    # These files are optional, depending on if they have been calculated.
+    # They may not exist
+    # They are named in "feattype_spatunit_postfix.extension" convention
+    
+    for (spat in spats) {
+        feats <- .gpoly_overlap_names(si[[spat]], type = "point")
+        if (is.null(feats)) next # goto next spat_unit if no overlaps
+        
+        for(feat in feats) {
+            
+            # format: feattype_spatunit
+            comb <- paste(feat, spat, sep = "_")
+            
+            # format: feattype_spatunit_postfix.extension
+            shp_file <- paste0(comb, "_spatInfo_spatVectorOverlaps.shp")
+            txt_file <- paste0(comb, "_spatInfo_spatVectorOverlaps_names.txt")
+            load_shp <- manifest[[shp_file]]
+            load_txt <- manifest[[txt_file]]
+            
+            vmsg(.v = verbose, .is_debug = TRUE, .initial = "  ",
+                 sprintf("[%s and %s] %s", spat, feat, basename(load_shp)))
+            spatVector <- terra::vect(load_shp)
+            
+            # read in original column names
+            spatVector_names <- data.table::fread(
+                input = load_txt, header = FALSE
+            )[["V1"]]
+            names(spatVector) <- spatVector_names
+            
+            # append
+            gobject@spatial_info[[spat]]@overlaps[[feat]] <- spatVector
+        }
+    }
+    
+    return(gobject)
+}
+
+
+.load_giotto_images <- function(gobject, path_to_folder, verbose = NULL) {
+    
+    vmsg(.v = verbose, "4. read Giotto image information")
+    vmsg(.v = verbose, .is_debug = TRUE, .initial = " ", 
+         box_chars()$l, "subdir: /Images/", sep = "")
+
+    imgs_dir <- file.path(path_to_folder, "Images")
+    manifest <- dir_manifest(imgs_dir)
+    basenames <- names(manifest)
+    
+    # basenames of imgs to load
+    img_files <- basenames[grepl("_spatRaster$", basenames)]
+    
+    # return early if none, also catches when dir does not exist
+    if (length(img_files) == 0) return(gobject)
+    
+    # parse the image name to load
+    imgs <- gsub(img_files, pattern = "_spatRaster", replacement = "")
+    
+    names(img_files) <- imgs
+    
+    for (img in imgs) {
+        load_img <- manifest[[img_files[[img]]]]
+        
+        vmsg(.v = verbose, .is_debug = TRUE, .initial = "  ",
+             sprintf("[%s] %s", img, basename(load_img)))
+        spatRaster <- terra::rast(load_img)
+        
+        gobject@images[[img]]@raster_object <- spatRaster
+        gobject@images[[img]]@file_path <- load_img
+    }
+    
+    return(gobject)
+}
+
+.gpoly_overlap_names <- function(x, type = c("point", "intensity")) {
+    type <- match.arg(type, choices = c("point", "intensity"))
+    ovlps <- overlaps(x)
+    if (is.null(ovlps)) return(NULL)
+    
+    switch(type,
+        "point" = {
+            res <- names(ovlps)
+            res <- res[res != "intensity"]
+            if (length(res) == 0) res <- NULL
+            return(res)
+        },
+        "intensity" = {
+            res <- names(ovlps$intensity)
+        }
+    )
+    return(res)
+}
+

--- a/man/get_expression_values.Rd
+++ b/man/get_expression_values.Rd
@@ -8,7 +8,7 @@ get_expression_values(
   gobject,
   spat_unit = NULL,
   feat_type = NULL,
-  values = NULL,
+  values = c("raw", "normalized", "scaled"),
   output = c("exprObj", "matrix"),
   set_defaults = TRUE
 )


### PR DESCRIPTION
- GiottoUtils version req bump to 0.1.10
- fix name parsing issue with `loadGiotto()`
  - previously, finding the file to load worked largely by regex with `list.files()`, but this has issues when you have names like `cell` and `new_cell` in the same object as the regex would pull both sets of info at once.
  - this update instead specifies the exact filename to use
  - exact filename is determined either by running 'gsub' on the available basenames or by checking the giotto object itself.
    - some further updates to make this detection more uniform may be good.