### PR TITLE
GiottoClass 0.4.2 - hotfix `makePseudoVisium()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,6 +77,7 @@ Suggests:
     testthat (>= 3.0.0),
     qs,
     xml2
+Remotes: drieslab/GiottoUtils
 Config/testthat/edition: 3
 Collate: 
     'package_imports.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GiottoClass
 Title: Giotto Suite object definitions and framework
-Version: 0.4.1
+Version: 0.4.2
 Authors@R: c(
 	person("Ruben", "Dries", email = "rubendries@gmail.com",
 		 role = c("aut", "cre"), comment = c(ORCID = "0000-0001-7650-7754")),
@@ -77,7 +77,6 @@ Suggests:
     testthat (>= 3.0.0),
     qs,
     xml2
-Remotes: drieslab/GiottoUtils
 Config/testthat/edition: 3
 Collate: 
     'package_imports.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 - `buffer()` for `giottoPolygon`, `giottoPoints`, `spatLocsObj`. Default is to crop by voronoi borders with `settleGeom()`
 - `settleGeom()` for `giottoPolygon` and `SpatVector` for finding non overlapping borders determined by voronoi
 
+## bug fixes
+- fix default method setting in `createNetwork()` for "delaunay" networks
+
 
 # GiottoClass 0.4.0 (2024/10/27)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# GiottoClass 0.4.2 (2024/10/30)
+
+## bug fixes
+- fix y spacing of `makePseudoVisium()`
+
+## changes
+- `makePseudoVisium()` `micron_scale` (multiplicative scalefactor to get micron scaled values) supercedes `micron_size` which used the inverse.
+
 
 # GiottoClass 0.4.1 (2024/10/28)
 

--- a/R/NN_network.R
+++ b/R/NN_network.R
@@ -143,15 +143,28 @@ createNetwork <- function(
 
     # check params
     type <- match.arg(type, choices = c("sNN", "kNN", "delaunay"))
+    
+    mdef <- c("dbscan", "geometry", "RTriangle", "deldir")
+    if (type %in% c("sNN", "kNN")) {
+        mchoices <- c("dbscan")
+        if (identical(method, mdef)) method <- mchoices
+    }
+    if (type %in% c("delaunay")) {
+        mchoices <- c("geometry", "RTriangle", "deldir")
+        if (identical(method, mdef)) method <- mchoices
+    }
+    
     method <- switch(type,
-        "sNN" = match.arg(method, choices = c("dbscan"), several.ok = TRUE),
-        "kNN" = match.arg(method, choices = c("dbscan"), several.ok = TRUE),
-        "delaunay" = match.arg(
-            method,
-            choices = c("geometry", "RTriangle", "deldir"),
-            several.ok = TRUE
-        )
+        "sNN" = match.arg(method, choices = mchoices, several.ok = TRUE),
+        "kNN" = match.arg(method, choices = mchoices, several.ok = TRUE),
+        "delaunay" = {
+            method <- method[[1L]]
+            match.arg(method, choices = mchoices, several.ok = TRUE)
+        }
     )
+    
+    vmsg(.is_debug = TRUE, sprintf("network\n type: %s\n method: %s",
+                                   type, method))
 
     # get common params
     alist <- list(

--- a/R/generate_poly.R
+++ b/R/generate_poly.R
@@ -382,26 +382,46 @@ orthoGrid <- function(extent, ccd, id_prefix = "ID_") {
 
 #' @title makePseudoVisium
 #' @name makePseudoVisium
-#' @description Generates a pseudo-visium grid of spots across a provided
-#' spatial extent
+#' @description Generates a visium-like array of spots across a provided
+#' spatial extent.
 #' @param extent SpatExtent or anything else a SpatExtent can be extracted or
 #' created from
-#' @param micron_size size of a micrometer relative to spatial coordinates
+#' @param micron_scale scalefactor needed to convert the target coordinate
+#' space to microns. For supported datasets, this can be found from 
+#' `instructions(gobject, "micron_scale")`. See details.
+#' @param micron_size deprecated. Use `micron_scale`
 #' @param name character. (default is 'pseudo_visium') Name of giottoPolygon
 #' object to create
-#' @details This function generates a pseudo-Visium grid of spots based on the
-#' input spatial locations. The micron_size param is used to determine the size
-#' of the spots
+#' @details This function generates a pseudo-Visium array of spots across the 
+#' spatial extent provided. The `micron_size` param is used to determine the 
+#' scaling of the array relative to the target coordinate system.
+#' 
+#' @section `micron_scale`: 
+#' If `a` is microns and `b` is dataset coordinate units, `micron_scale` is
+#' calculated as `a / b`.
 #' @returns A giottoPolygon for the pseudo-visium spots.
 #' @examples
 #' e <- ext(0, 2000, 0, 2000)
-#' x <- makePseudoVisium(extent = e, micron_size = 1)
+#' x <- makePseudoVisium(extent = e, micron_scale = 1)
 #' plot(x)
 #' @concept spatial location
 #' @export
 makePseudoVisium <- function(extent = NULL,
-    micron_size = 1,
+    micron_scale = 1,
+    micron_size = deprecated(),
     name = "pseudo_visium") {
+    
+    if (is_present(micron_size)) {
+        micron_size <- 1 / micron_size
+    }
+    
+    micron_scale <- deprecate_param(
+        x = micron_size,
+        y = micron_scale,
+        when = "0.4.2",
+        fun = "makePseudoVisium"
+    )
+    
     e <- ext(extent)[]
 
     # Visium default scale parameters
@@ -410,19 +430,23 @@ makePseudoVisium <- function(extent = NULL,
     visium_gap_um <- 45
 
     # Compute metrics to visium scale
-    radius <- visium_radius_um / micron_size
+    cc <- visium_center_center_dist_um / micron_scale
+    radius <- visium_radius_um / micron_scale
     gap <- (visium_gap_um / visium_radius_um) * radius
 
     # Define a data.table with the vertices of a circle centered around (0,0)
     stamp_dt <- circleVertices(radius = radius, npoints = 100)
 
     # Create a grid of y points where the circles will be centered
-    y_seq <- seq(e[["ymin"]] + radius, e[["ymax"]] - radius,
-        by = 2 * radius + gap
+    y_seq <- seq(
+        e[["ymin"]] + radius, 
+        e[["ymax"]] - radius,
+        # should be sqrt(3) or 1.732051, but seems like it was rounded
+        by = 1.74 * (cc / 2)
     )
 
     # Stagger center point of circles to match visium staggered grid
-    centers <- data.table::rbindlist(lapply(seq_len(length(y_seq)), function(i) {
+    dt_list <- lapply(seq_len(length(y_seq)), function(i) {
         x_start <- if (i %% 2 == 0) {
             e[["xmin"]] + radius + (2 * radius + gap) / 2
         } else {
@@ -430,7 +454,8 @@ makePseudoVisium <- function(extent = NULL,
         }
         x_seq <- seq(x_start, e[["xmax"]] - radius, by = 2 * radius + gap)
         data.table::data.table(sdimx = x_seq, sdimy = y_seq[i])
-    }))
+    })
+    centers <- data.table::rbindlist(dt_list)
     centers$cell_ID <- paste0("spot_", seq_len(nrow(centers)))
 
     # Call polyStamp function on centers to generate the pseudo-visium grid

--- a/R/generate_poly.R
+++ b/R/generate_poly.R
@@ -393,7 +393,7 @@ orthoGrid <- function(extent, ccd, id_prefix = "ID_") {
 #' @param name character. (default is 'pseudo_visium') Name of giottoPolygon
 #' object to create
 #' @details This function generates a pseudo-Visium array of spots across the 
-#' spatial extent provided. The `micron_size` param is used to determine the 
+#' spatial extent provided. The `micron_scale` param is used to determine the 
 #' scaling of the array relative to the target coordinate system.
 #' 
 #' @section `micron_scale`: 

--- a/man/makePseudoVisium.Rd
+++ b/man/makePseudoVisium.Rd
@@ -33,7 +33,7 @@ spatial extent.
 }
 \details{
 This function generates a pseudo-Visium array of spots across the
-spatial extent provided. The \code{micron_size} param is used to determine the
+spatial extent provided. The \code{micron_scale} param is used to determine the
 scaling of the array relative to the target coordinate system.
 }
 \section{\code{micron_scale}}{

--- a/man/makePseudoVisium.Rd
+++ b/man/makePseudoVisium.Rd
@@ -4,13 +4,22 @@
 \alias{makePseudoVisium}
 \title{makePseudoVisium}
 \usage{
-makePseudoVisium(extent = NULL, micron_size = 1, name = "pseudo_visium")
+makePseudoVisium(
+  extent = NULL,
+  micron_scale = 1,
+  micron_size = deprecated(),
+  name = "pseudo_visium"
+)
 }
 \arguments{
 \item{extent}{SpatExtent or anything else a SpatExtent can be extracted or
 created from}
 
-\item{micron_size}{size of a micrometer relative to spatial coordinates}
+\item{micron_scale}{scalefactor needed to convert the target coordinate
+space to microns. For supported datasets, this can be found from
+\code{instructions(gobject, "micron_scale")}. See details.}
+
+\item{micron_size}{deprecated. Use \code{micron_scale}}
 
 \item{name}{character. (default is 'pseudo_visium') Name of giottoPolygon
 object to create}
@@ -19,17 +28,23 @@ object to create}
 A giottoPolygon for the pseudo-visium spots.
 }
 \description{
-Generates a pseudo-visium grid of spots across a provided
-spatial extent
+Generates a visium-like array of spots across a provided
+spatial extent.
 }
 \details{
-This function generates a pseudo-Visium grid of spots based on the
-input spatial locations. The micron_size param is used to determine the size
-of the spots
+This function generates a pseudo-Visium array of spots across the
+spatial extent provided. The \code{micron_size} param is used to determine the
+scaling of the array relative to the target coordinate system.
 }
+\section{\code{micron_scale}}{
+
+If \code{a} is microns and \code{b} is dataset coordinate units, \code{micron_scale} is
+calculated as \code{a / b}.
+}
+
 \examples{
 e <- ext(0, 2000, 0, 2000)
-x <- makePseudoVisium(extent = e, micron_size = 1)
+x <- makePseudoVisium(extent = e, micron_scale = 1)
 plot(x)
 }
 \concept{spatial location}


### PR DESCRIPTION
## bug fixes
- fix y spacing of `makePseudoVisium()`

## changes
- `makePseudoVisium()` `micron_scale` (multiplicative scalefactor to get micron scaled values) supercedes `micron_size` which used the inverse.