### PR TITLE
GiottoClass 0.4.4 hotfixes for affine image save/loads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GiottoClass
 Title: Giotto Suite object definitions and framework
-Version: 0.4.3
+Version: 0.4.4
 Authors@R: c(
 	person("Ruben", "Dries", email = "rubendries@gmail.com",
 		 role = c("aut", "cre"), comment = c(ORCID = "0000-0001-7650-7754")),
@@ -77,7 +77,6 @@ Suggests:
     testthat (>= 3.0.0),
     qs,
     xml2
-Remotes: drieslab/GiottoUtils
 Config/testthat/edition: 3
 Collate: 
     'package_imports.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,6 +77,7 @@ Suggests:
     testthat (>= 3.0.0),
     qs,
     xml2
+Remotes: drieslab/GiottoUtils
 Config/testthat/edition: 3
 Collate: 
     'package_imports.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## bug fixes
 - fix cell metadata desyncing after `joinGiottoObjects()`
 - fix `readExprMatrix()` when IDs are numerical barcodes
+- fix `giottoAffineImage` `reconnect()` method
 
 ## enhancements
 - `saveGiotto()` now has `include_feat_coord` param. If `FALSE`, transcript coordinates will be dropped during saving, which will make the object much less memory intensive.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## bug fixes
 - fix cell metadata desyncing after `joinGiottoObjects()`
 - fix `readExprMatrix()` when IDs are numerical barcodes
+- fix `giottoAffineImage` not being detected during `saveGiotto()` image export step.
 - fix `giottoAffineImage` `reconnect()` method
 
 ## enhancements

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 ## enhancements
 - `saveGiotto()` now has `include_feat_coord` param. If `FALSE`, transcript coordinates will be dropped during saving, which will make the object much less memory intensive.
-
+- `saveGiotto()` now has a `export_image` param. If `FALSE`, the image will not be re-exported during the save process. (They can still be reconnected)
 
 # GiottoClass 0.4.2 (2024/10/30)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# GiottoClass 0.4.3 (2024/11/12)
+# GiottoClass 0.4.4 (2024/11/14)
 
 ## bug fixes
 - fix cell metadata desyncing after `joinGiottoObjects()`

--- a/R/methods-reconnect.R
+++ b/R/methods-reconnect.R
@@ -6,18 +6,41 @@
 #' has changed.
 #' @param ... additional params to pass
 #' @returns GiottoClass object
+#' @examples
+#' f <- tempfile()
+#' a <- GiottoData::loadSubObjectMini("giottoLargeImage")
+#' saveRDS(a, f)
+#' 
+#' b <- readRDS(f) # expected to be null pointer
+#' b <- reconnect(b) # reconnected to source image
 NULL
 
 
 
+#' @rdname reconnect
+#' @export
+setMethod("reconnect", signature("giottoAffineImage"), function(x, path = NULL, ...) {
+    path <- path %null% slot(x, "file_path")
+    .image_path_checks(path)
+    
+    # replace old raster objects
+    raster_object <- .create_terra_spatraster(image_path = path)
+    slot(x, "raster_object") <- raster_object
+
+    # inherit tracked extents (image extent and user-facing extent)
+    img_ext <- x@affine@anchor
+    user_ext <- x@extent
+    
+    # this method affects multiple slots, including the extent of the image, so do first
+    ext(x) <- user_ext 
+    # this only affects the image extent, so do second
+    ext(x@raster_object) <- img_ext
+    
+    return(initialize(x))
+})
 
 
 #' @rdname reconnect
-#' @examples
-#' g <- GiottoData::loadGiottoMini("visium")
-#' g_image <- getGiottoImage(g, image_type = "largeImage")
-#'
-#' reconnect(g_image)
 #' @export
 setMethod("reconnect", signature("giottoLargeImage"), function(x, path = NULL, ...) {
     path <- path %null% slot(x, "file_path")
@@ -26,9 +49,9 @@ setMethod("reconnect", signature("giottoLargeImage"), function(x, path = NULL, .
     # replace old raster objects and inherit tracked extents
     raster_object <- .create_terra_spatraster(image_path = path)
     slot(x, "raster_object") <- raster_object
-    terra::ext(slot(x, "raster_object")) <- slot(x, "extent")
+    ext(slot(x, "raster_object")) <- slot(x, "extent")
 
-    return(x)
+    return(initialize(x))
 })
 
 

--- a/R/slot_list.R
+++ b/R/slot_list.R
@@ -980,17 +980,15 @@ list_images <- function(gobject,
         function(img) {
             data.table::data.table(
                 name = objName(img),
-                img_type = class(img)
+                img_type = if (inherits(img, "giottoLargeImage")) {
+                    "largeImage"
+                } else if (inherits(img, "giottoImage")) {
+                    "image"
+                }
             )
         }
     )
     avail_imgs <- data.table::rbindlist(img_info)
-
-    # change to shortnames for img_type
-    if (nrow(avail_imgs) > 0) {
-        avail_imgs[img_type == "giottoLargeImage", img_type := "largeImage"]
-        avail_imgs[img_type == "giottoImage", img_type := "image"]
-    }
 
     # check if a specific category is desired
     if (!is.null(img_type)) {


### PR DESCRIPTION
## bug fixes
- fix `giottoAffineImage` not being detected during `saveGiotto()` image export step.
- fix `giottoAffineImage` `reconnect()` method

## enhancements
- `saveGiotto()` now has a `export_image` param. If `FALSE`, the image will not be re-exported during the save process. (They can still be reconnected)