### PR TITLE
fix: terra rast() noflip

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     methods,
     reticulate (>= 1.25),
     stats,
-    terra (>= 1.7-41)
+    terra (>= 1.8-21)
 Suggests: 
     Biobase,
     chihaya,

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,9 +14,11 @@
 - replace internal usage of deprecated create_spat_net_obj -> createSpatNetObj and set_spatialNetwork -> setSpatialNetwork when calculating spatial networks.
 - fix `createGiottoPolygon()` not preserving attributes from `data.table` inputs
 - fix `loadGiotto()` error when a non-expected reticulate environment is already activated in the session
+- fix `createGiottoLargeImage()` and `createGiottoPolygonsFromMask()` to align with {terra} `v1.8-21` `rast(noflip = TRUE)` [#1102](https://github.com/drieslab/Giotto/issues/1102) by StevenWijnen and rbutleriii
 
 ## changes
 - move {magick} from imports to suggests
+- {terra} `>=v1.8-21`
 
 ## enhancements
 - `[[` can now be used to select channels in `giottoLargeImage`-inheriting objects

--- a/R/create.R
+++ b/R/create.R
@@ -2363,7 +2363,7 @@ setMethod(
         # try failure means it should be vector file
         try_rast <- tryCatch(
             {
-                terra::rast(x)
+                .create_terra_spatraster(x)
             },
             error = function(e) {
                 return(invisible(NULL))
@@ -2426,10 +2426,10 @@ setMethod(
     fill_holes = TRUE,
     poly_IDs = NULL,
     ID_fmt = "cell_",
-    flip_vertical = TRUE,
-    shift_vertical_step = TRUE,
-    flip_horizontal = TRUE,
-    shift_horizontal_step = TRUE,
+    flip_vertical = FALSE,
+    shift_vertical_step = FALSE,
+    flip_horizontal = FALSE,
+    shift_horizontal_step = FALSE,
     remove_unvalid_polygons = TRUE,
     calc_centroids = FALSE,
     verbose = TRUE) {
@@ -2493,10 +2493,12 @@ setMethod(
 #' each polygon in the mask file.
 #' @param ID_fmt character. Only applied if `poly_IDs = NULL`. Naming scheme for
 #' poly_IDs. Default = "cell_". See *ID_fmt* section.
-#' @param flip_vertical flip mask figure in a vertical manner
-#' @param shift_vertical_step shift vertical (boolean or numerical)
-#' @param flip_horizontal flip mask figure in a horizontal manner
-#' @param shift_horizontal_step shift horizontal (boolean or numerical)
+#' @param flip_vertical,flip_horizontal logical. Flip output polygons across y
+#' (vertical) or x (horizontal) axis.
+#' @param shift_vertical_step,shift_horizontal_step logical or numeric. When
+#' `FALSE`, no shift is performed. When numeric, a shift of
+#' \eqn{image height \times step} (vertical) or \eqn{image width \times step}
+#' (horizontal) is performed.
 #' @param remove_unvalid_polygons remove unvalid polygons (default: TRUE)
 #' @concept mask polygon
 #' @section mask_method:
@@ -2532,10 +2534,10 @@ createGiottoPolygonsFromMask <- function(
         fill_holes = TRUE,
         poly_IDs = NULL,
         ID_fmt = "cell_",
-        flip_vertical = TRUE,
-        shift_vertical_step = TRUE,
-        flip_horizontal = TRUE,
-        shift_horizontal_step = TRUE,
+        flip_vertical = FALSE,
+        shift_vertical_step = FALSE,
+        flip_horizontal = FALSE,
+        shift_horizontal_step = FALSE,
         calc_centroids = FALSE,
         remove_unvalid_polygons = TRUE,
         verbose = FALSE) {
@@ -2593,10 +2595,12 @@ createGiottoPolygonsFromMask <- function(
 
     ## flip across axes ##
     if (isTRUE(flip_vertical)) {
-        terra_polygon <- .flip_spatvect(terra_polygon)
+        terra_polygon <- .flip_spatvect(terra_polygon,
+            direction = "vertical")
     }
     if (isTRUE(flip_horizontal)) {
-        terra_polygon <- .flip_spatvect(terra_polygon)
+        terra_polygon <- .flip_spatvect(terra_polygon,
+            direction = "horizontal")
     }
 
     # convert to DT format since we want to be able to compare number of geoms

--- a/R/images.R
+++ b/R/images.R
@@ -682,7 +682,7 @@ reconnect_giottoImage_MG <- function(
 #' @keywords internal
 #' @returns spatRaster object
 .create_terra_spatraster <- function(image_path) {
-    raster_object <- try(handle_warnings(terra::rast(x = image_path))$result)
+    raster_object <- try(terra::rast(x = image_path, noflip = TRUE))
     if (inherits(raster_object, "try-error")) {
         stop(raster_object, " can not be read by terra::rast() \n")
     }

--- a/R/interoperability.R
+++ b/R/interoperability.R
@@ -2509,7 +2509,7 @@ seuratToGiottoV5 <- function(sobject,
 
 
 
-    # Find SueratImages, extract them, and pass to create image
+    # Find SeuratImages, extract them, and pass to create image
     image_list <- list()
     for (i in names(sobject@images)) {
         simg <- sobject[[i]]

--- a/R/methods-flip.R
+++ b/R/methods-flip.R
@@ -165,15 +165,6 @@ setMethod(
 
 #' @rdname flip
 #' @export
-setMethod("flip", signature("giottoLargeImage"), function(x, direction = "vertical", x0 = 0, y0 = 0) {
-    a <- get_args_list()
-    a$x <- as(x, "giottoAffineImage") # convert to giottoAffineImage
-    res <- do.call(flip, args = a)
-    return(res)
-})
-
-#' @rdname flip
-#' @export
 setMethod("flip", signature("giottoAffineImage"), function(x, direction = "vertical", x0 = 0, y0 = 0) {
     a <- get_args_list()
     a$x <- x@affine
@@ -367,9 +358,6 @@ setMethod("flip", signature("affine2d"), function(x, direction = "vertical", x0 
 
 #' @name .flip_large_image
 #' @title Flip a giottoLargeImage object
-#' @description Flip a giottoPoints over a designated x or y value depending on
-#' direction param input. Note that this behavior is different from terra's
-#' implementation of flip for SpatVectors where flips happen over the extent
 #' @param image giottoLargeImage
 #' @param direction character. Direction to flip. Should be either partial
 #' match to 'vertical' or 'horizontal'

--- a/man/createGiottoPolygon.Rd
+++ b/man/createGiottoPolygon.Rd
@@ -24,10 +24,10 @@
   fill_holes = TRUE,
   poly_IDs = NULL,
   ID_fmt = "cell_",
-  flip_vertical = TRUE,
-  shift_vertical_step = TRUE,
-  flip_horizontal = TRUE,
-  shift_horizontal_step = TRUE,
+  flip_vertical = FALSE,
+  shift_vertical_step = FALSE,
+  flip_horizontal = FALSE,
+  shift_horizontal_step = FALSE,
   remove_unvalid_polygons = TRUE,
   calc_centroids = FALSE,
   verbose = TRUE
@@ -53,10 +53,10 @@ createGiottoPolygonsFromMask(
   fill_holes = TRUE,
   poly_IDs = NULL,
   ID_fmt = "cell_",
-  flip_vertical = TRUE,
-  shift_vertical_step = TRUE,
-  flip_horizontal = TRUE,
-  shift_horizontal_step = TRUE,
+  flip_vertical = FALSE,
+  shift_vertical_step = FALSE,
+  flip_horizontal = FALSE,
+  shift_horizontal_step = FALSE,
   calc_centroids = FALSE,
   remove_unvalid_polygons = TRUE,
   verbose = FALSE
@@ -112,13 +112,13 @@ each polygon in the mask file.}
 \item{ID_fmt}{character. Only applied if \code{poly_IDs = NULL}. Naming scheme for
 poly_IDs. Default = "cell_". See \emph{ID_fmt} section.}
 
-\item{flip_vertical}{flip mask figure in a vertical manner}
+\item{flip_vertical, flip_horizontal}{logical. Flip output polygons across y
+(vertical) or x (horizontal) axis.}
 
-\item{shift_vertical_step}{shift vertical (boolean or numerical)}
-
-\item{flip_horizontal}{flip mask figure in a horizontal manner}
-
-\item{shift_horizontal_step}{shift horizontal (boolean or numerical)}
+\item{shift_vertical_step, shift_horizontal_step}{logical or numeric. When
+\code{FALSE}, no shift is performed. When numeric, a shift of
+\eqn{image height \times step} (vertical) or \eqn{image width \times step}
+(horizontal) is performed.}
 
 \item{remove_unvalid_polygons}{remove unvalid polygons (default: TRUE)}
 

--- a/man/flip.Rd
+++ b/man/flip.Rd
@@ -31,11 +31,9 @@
 
 \S4method{flip}{spatialNetworkObj}(x, direction = "vertical", x0 = 0, y0 = 0, ...)
 
-\S4method{flip}{giottoLargeImage}(x, direction = "vertical", x0 = 0, y0 = 0)
+\S4method{flip}{giottoLargeImage}(x, direction = "vertical", x0 = 0, y0 = 0, ...)
 
 \S4method{flip}{SpatExtent}(x, direction = "vertical", x0 = 0, y0 = 0)
-
-\S4method{flip}{giottoLargeImage}(x, direction = "vertical", x0 = 0, y0 = 0)
 
 \S4method{flip}{giottoAffineImage}(x, direction = "vertical", x0 = 0, y0 = 0)
 

--- a/man/relate.Rd
+++ b/man/relate.Rd
@@ -32,7 +32,7 @@
 
 \item{y}{spatial object records to test relations against}
 
-\item{relation}{character. One of "intersects", "touches", "crosses", "overlaps", "within", "contains", "covers", "coveredby", "disjoint". Or a "DE-9IM" string such as "FF*FF****". See \href{https://en.wikipedia.org/wiki/DE-9IM}{wikipedia} or \href{https://docs.geotools.org/stable/userguide/library/jts/dim9.html}{geotools doc}}
+\item{relation}{character. One of "intersects", "touches", "crosses", "overlaps", "within", "contains", "covers", "coveredby", "disjoint", or "equals". It can also be a "DE-9IM" string such as "FF*FF****". See \href{https://en.wikipedia.org/wiki/DE-9IM}{Wikipedia} or \href{https://docs.geotools.org/stable/userguide/library/jts/dim9.html}{GeoTools doc}}
 
 \item{pairs}{logical. If \code{TRUE} a two-column matrix is returned with the indices of the cases where the requested relation is \code{TRUE}. This is especially helpful when dealing with many geometries as the returned value is generally much smaller}
 


### PR DESCRIPTION
- require terra (>= 1.8-21)
- update raster loading functions with `noflip` changes in `rast()`
- possible behavior changes in createGiottoLargeImage() and createGiottoPolygonsFromMask()