### PR TITLE
Add missing parameter definitions

### DIFF
--- a/R/interoperability.R
+++ b/R/interoperability.R
@@ -203,18 +203,22 @@ check_py_for_scanpy <- function() {
 #' @param n_key_added equivalent of "key_added" argument from scanpy.pp.
 #' neighbors(). If multiple spatial networks are in the anndata object, a list
 #' of key_added terms may be provided. If converting an anndata object from
-#' giottoToAnnData, a .txt file may be provided, which was generated in that
-#' function, i.e. \{spat_unit\}_\{feat_type\}_nn_network_keys_added.txt. Cannot
-#' be "spatial". This becomes the name of the nearest network in the gobject.
+#' giottoToAnnData, the keys are saved in .uns['NN_keys']
+#' and all keys are used in conversion unless specified in the function call.
+#' Cannot be "spatial". This becomes the name of the nearest network in the gobject.
 #' @param spatial_n_key_added equivalent of "key_added" argument from
 #' squidpy.gr.spatial_neighbors. If multiple spatial networks are in the
 #' anndata object, a list of key_added terms may be provided. If converting an
-#' anndata object from giottoToAnnData, a .txt file may be provided, which was
-#' generated in that function,
-#' i.e. \{spat_unit\}_\{feat_type\}_spatial_network_keys_added.txt
+#' anndata object from giottoToAnnData, the keys are saved in .uns['SN_keys']
+#' and all keys are used in conversion unless specified in the function call.
 #' Cannot be the same as n_key_added.
 #' @param delaunay_spat_net binary parameter for spatial network. If TRUE, the
 #' spatial network is a delaunay network.
+#' @param spat_enrich_key_added 
+#' list of names of spatial enrichment annotations present in the anndata object.
+#' If converting an anndata object from giottoToAnnData and the original Giotto object had
+#' spatial enrichment annotations, the keys are saved in .uns['SE_keys']
+#' and all keys are used in conversion unless specified in the function call.
 #' @param spat_unit desired spatial unit to use for conversion, default NULL
 #' @param feat_type desired feature type to use for conversion, default NULL
 #' @param h5_file name to create and on-disk HDF5 file
@@ -3491,20 +3495,23 @@ giottoMasterToSuite <- function(gobject,
 #' @param n_key_added equivalent of "key_added" argument from scanpy.pp.neighbors().
 #' If multiple spatial networks are in the anndata object, a list of key_added
 #' terms may be provided.
-#' If converting an anndata object from giottoToAnnData, a .txt file may be
-#' provided, which was generated in that function,
-#'       i.e. \{spat_unit\}_\{feat_type\}_nn_network_keys_added.txt
+#' If converting an anndata object from giottoToAnnData, the keys are saved in .uns['NN_keys']
+#' and all keys are used in conversion unless specified in the function call.
 #' Cannot be "spatial". This becomes the name of the nearest network in the gobject.
 #' @param spatial_n_key_added
 #' equivalent of "key_added" argument from squidpy.gr.spatial_neighbors.
 #' If multiple spatial networks are in the anndata object, a list of key_added
 #' terms may be provided.
-#' If converting an anndata object from giottoToAnnData, a .txt file may be
-#' provided, which was generated in that function,
-#'     i.e. \{spat_unit\}_\{feat_type\}_spatial_network_keys_added.txt
+#' If converting a SpatialData object from giottoToSpatialData, the keys are saved in .uns['SN_keys']
+#' and all keys are used in conversion unless specified in the function call.
 #' Cannot be the same as n_key_added.
 #' @param delaunay_spat_net binary parameter for spatial network. If TRUE,
 #' the spatial network is a delaunay network.
+#' @param spat_enrich_key_added
+#' list of names of spatial enrichment annotations added to the SpatialData object.
+#' If converting an anndata object from giottoToAnnData and the original Giotto object had
+#' spatial enrichment annotations, the keys are saved in .uns['SE_keys']
+#' and all keys are used in conversion unless specified in the function call.
 #' @param spat_unit desired spatial unit for conversion, default NULL
 #' @param feat_type desired feature type for conversion, default NULL
 #' @param python_path path to python executable within a conda/miniconda environment


### PR DESCRIPTION
Added missing parameter definitions for anndataToGiotto and spatialDataToGiotto. Also updated parameter defintions regarding the updated handling of spatial network and nearest neighbor network keys. 