### PR TITLE
xenium spat locations bug fixes

### DIFF
--- a/R/interoperability.R
+++ b/R/interoperability.R
@@ -3742,7 +3742,7 @@ spatialdataToGiotto <- function(
             gobject <- setSpatialLocations(
                 gobject,
                 x = createSpatLocsObj(spatial_dict[[key]], name = "raw"),
-                spat_unit = "cell")
+                spat_unit = key)
         }
     }
     sp_dict <- parse_obsm_for_spat_locs(sdata)


### PR DESCRIPTION
Spatial locations are usually stored in spatialdata.table slot (as anndata). However, if multiple spatialdata.shapes are found, spatial locations are also extracted from the polygons through manually computing the centroids, and the spatial locations are added to Giotto object with the polygon name designations. 