### PR TITLE
fix: .evaluate_*_network accept dataStore-backed @network (partial)

### DIFF
--- a/R/data_evaluation.R
+++ b/R/data_evaluation.R
@@ -475,6 +475,13 @@ evaluate_input <- function(type, x, ...) {
         return(spatial_network)
     }
 
+    # disk-backed networks (e.g. parquetEdgeStore from GiottoDisk's
+    # setter auto-write or sourceAdopt path) are already validated at
+    # write time; pass through unchanged.
+    if (inherits(spatial_network, "dataStore")) {
+        return(spatial_network)
+    }
+
     # data.frame-shaped fallback (legacy + edge-table inputs)
     if (!inherits(spatial_network, "data.frame")) {
         .gstop("The spatial network must be an igraph or data.frame(-like) object")
@@ -632,6 +639,11 @@ evaluate_input <- function(type, x, ...) {
 
     if (inherits(nn_network, "nnNetObj")) {
         nn_network[] <- .evaluate_nearest_networks(nn_network = nn_network[])
+        return(nn_network)
+    } else if (inherits(nn_network, "dataStore")) {
+        # disk-backed networks (e.g. parquetEdgeStore from GiottoDisk's
+        # setter auto-write or sourceAdopt path) are already validated
+        # at write time; pass through unchanged.
         return(nn_network)
     } else if (inherits(nn_network, "igraph")) {
         v_attr <- igraph::vertex_attr_names(nn_network)


### PR DESCRIPTION
## The bug

When a backed gobject's \`setNearestNetwork\` / \`setSpatialNetwork\` auto-write converts an in-memory igraph to a parquetEdgeStore (GiottoDisk side), the \`@network\` slot on the nnNetObj / spatialNetworkObj becomes a \`dataStore\`. The downstream validators in \`R/data_evaluation.R\` recurse into nnNetObj / spatialNetworkObj via:

\`\`\`r
nn_network[] <- .evaluate_nearest_networks(nn_network = nn_network[])
\`\`\`

The recursive call had branches only for \`nnNetObj\` / \`igraph\` / \`data.frame\`. When \`@network\` was already a parquetEdgeStore, none matched, the function fell through, returned implicit NULL, and the recursive assignment **silently nulled \`@network\`**. Downstream code then hit "Must provide a graph object" when igraph functions were called on NULL.

## Fix

Add an \`inherits(x, "dataStore")\` early-return branch in both \`.evaluate_spatial_network\` and \`.evaluate_nearest_networks\`. dataStore-backed networks are validated at write time by GiottoDisk; re-validation here is a pass-through.

## Scope — this is a **partial fix**

Prevents \`@network\` nullification at the validator layer but doesn't unblock the full external-adoption path. The remaining gap is in [methods-IDs.R:236](R/methods-IDs.R#L236) and [L137](R/methods-IDs.R#L137):

- \`spatIDs(nnNetObj)\` calls \`igraph::V(x@network)\` directly.
- \`spatIDs(spatialNetworkObj)\` calls \`x[]\$from\` directly.

Both fail when \`@network\` is a parquetEdgeStore. Fixing these cleanly likely wants a \`nodeIDs()\` generic that GiottoDisk can specialize. Separate piece of work.

## Why this is worth landing alone

- Defensive: prevents silent NULL-corruption of network slots. That bug exists today on every code path that re-validates an already-parquetEdgeStore-backed network.
- Tiny diff, no API change.
- Unblocks one layer of the full federated-multi networks story.

## Test plan
- [x] \`devtools::test()\` — existing accessor tests pass.
- [ ] Round-trip test for parquetEdgeStore-backed network through \`setGiotto\` once Layer 2 fix lands.