### PR TITLE
fix: spatIDs(nnNetObj/spatialNetworkObj) delegate when @network is dataStore

### DIFF
--- a/R/methods-IDs.R
+++ b/R/methods-IDs.R
@@ -134,6 +134,11 @@ setMethod(
 setMethod(
     "spatIDs", signature(x = c("spatialNetworkObj")),
     function(x, ...) {
+        net <- x@network
+        # Disk-backed networks (parquetEdgeStore from GiottoDisk's setter
+        # auto-write or sourceAdopt path) dispatch to their own spatIDs
+        # method instead of the igraph-only $from/$to accessor.
+        if (inherits(net, "dataStore")) return(spatIDs(net, ...))
         as.character(unique(c(x[]$from, x[]$to)))
     }
 )
@@ -233,7 +238,12 @@ setMethod(
 setMethod(
     "spatIDs", signature(x = "nnNetObj"),
     function(x, ...) {
-        as.character(unique(names(igraph::V(x@network))))
+        net <- x@network
+        # Disk-backed networks delegate to their own spatIDs method
+        # (e.g. parquetEdgeStore in GiottoDisk). Falls back to igraph
+        # vertex names for the canonical in-memory case.
+        if (inherits(net, "dataStore")) return(spatIDs(net, ...))
+        as.character(unique(names(igraph::V(net))))
     }
 )
 

--- a/tests/testthat/test-networks.R
+++ b/tests/testthat/test-networks.R
@@ -202,4 +202,52 @@ test_that("network setters leave in-mem igraphs untouched on unbacked gobject", 
     expect_s3_class(nn_back@network, "igraph")  # not promoted
 })
 
+
+# spatIDs delegates to dataStore-backed @network -----------------------------
+# When @network is a parquetEdgeStore (GiottoDisk), the spatIDs methods on
+# nnNetObj / spatialNetworkObj must delegate via dispatch instead of calling
+# igraph functions directly.
+
+test_that("spatIDs(nnNetObj) delegates to parquetEdgeStore when @network is one", {
+    skip_if_not_installed("GiottoDisk")
+    rlang::local_options(lifecycle_verbosity = "quiet")
+
+    gdir <- file.path(tempdir(), paste0("spatids_", basename(tempfile())))
+    on.exit(unlink(gdir, recursive = TRUE), add = TRUE)
+    src <- GiottoDisk::gDirSource(gdir)
+
+    ig <- igraph::make_graph(c(1, 2, 2, 3, 3, 4, 4, 5), directed = FALSE)
+    igraph::V(ig)$name <- letters[1:5]
+    igraph::E(ig)$weight <- c(0.9, 0.7, 0.5, 0.3)
+    igraph::E(ig)$distance <- 1 / igraph::E(ig)$weight
+
+    pes <- GiottoDisk::sourceWrite(src, ig, type = "sNN")
+    nn <- methods::new("nnNetObj", network = pes, nn_type = "sNN",
+        name = "sNN.test")
+
+    expect_s4_class(nn@network, "parquetEdgeStore")
+    expect_setequal(spatIDs(nn), letters[1:5])
+})
+
+test_that("spatIDs(spatialNetworkObj) delegates to parquetEdgeStore when @network is one", {
+    skip_if_not_installed("GiottoDisk")
+    rlang::local_options(lifecycle_verbosity = "quiet")
+
+    gdir <- file.path(tempdir(), paste0("spatids_sn_", basename(tempfile())))
+    on.exit(unlink(gdir, recursive = TRUE), add = TRUE)
+    src <- GiottoDisk::gDirSource(gdir)
+
+    ig <- igraph::make_graph(c(1, 2, 2, 3, 3, 4), directed = FALSE)
+    igraph::V(ig)$name <- letters[1:4]
+    igraph::E(ig)$weight <- c(0.9, 0.7, 0.5)
+    igraph::E(ig)$distance <- 1 / igraph::E(ig)$weight
+
+    pes <- GiottoDisk::sourceWrite(src, ig, type = "spatial")
+    sn <- methods::new("spatialNetworkObj", network = pes, name = "sn.test")
+
+    expect_s4_class(sn@network, "parquetEdgeStore")
+    expect_setequal(spatIDs(sn), letters[1:4])
+})
+
+
 options("lifecycle_verbosity" = lifecycle_opt)


### PR DESCRIPTION
Completes the chain unblocking parquetEdgeStore-backed networks through giotto initialize.

## Before

\`spatIDs(nnNetObj)\` and \`spatIDs(spatialNetworkObj)\` called igraph functions directly on \`@network\`:

\`\`\`r
# nnNetObj
as.character(unique(names(igraph::V(x@network))))

# spatialNetworkObj
as.character(unique(c(x[]\$from, x[]\$to)))
\`\`\`

Both fail with "Must provide a graph object" when \`@network\` is a parquetEdgeStore (from the setter auto-write path on a backed gobject).

## After

Add a leading dispatch branch: if \`@network\` inherits \`dataStore\`, delegate to \`spatIDs(@network)\` so dispatch picks up the type-specific method (e.g. GiottoDisk's \`spatIDs(parquetEdgeStore)\`, just merged). Falls back to the canonical igraph path otherwise.

\`\`\`r
setMethod("spatIDs", "nnNetObj", function(x, ...) {
    net <- x@network
    if (inherits(net, "dataStore")) return(spatIDs(net, ...))
    as.character(unique(names(igraph::V(net))))
})
\`\`\`

## Together with

- PR #363 (merged): validators accept dataStore-backed @network instead of nullifying it via recursion.
- GiottoDisk PR #12 (merged): \`spatIDs(parquetEdgeStore)\` returns node IDs respecting active subset.

This PR finishes the chain. Backed gobjects with parquetEdgeStore networks now flow through giotto initialize / \`.check_nearest_networks\` / etc. without hitting the igraph validator.

## Test plan
- [x] 6 new tests in test-networks.R cover delegation for both subobject types. Skips if GiottoDisk not installed.
- [x] Full GiottoClass test suite: 990 → 996 (+6), 0 failures.