### PR TITLE
feat: assemble cell metadata tags each row with list_ID = child name

### DIFF
--- a/R/gmulti.R
+++ b/R/gmulti.R
@@ -962,6 +962,10 @@ setMethod("show", "giottoMulti", function(object) {
         if (is.null(cm)) return(NULL)
         dt <- data.table::copy(cm[])
         dt[, cell_ID := paste(nm, cell_ID, sep = "::")]
+        # Sample-origin tag — matches joinGiottoObjects' convention so
+        # downstream tools (e.g. runGiottoHarmony's vars_use = "list_ID"
+        # default) work out of the box on the assembled multi metadata.
+        dt[, list_ID := nm]
         list(cm = cm, dt = dt)
     })
     per_child <- Filter(Negate(is.null), per_child)

--- a/tests/testthat/test-gmulti.R
+++ b/tests/testthat/test-gmulti.R
@@ -760,6 +760,21 @@ test_that("pDataDT / fDataDT work on giottoMulti via assembly fallback", {
     expect_identical(sort(fd$feat_ID), paste0("f", 1:4))
 })
 
+test_that("pDataDT assembly tags each row with list_ID = child name", {
+    g1 <- .mk_minimal(5, 4)
+    g2 <- .mk_minimal(3, 4)
+    mg <- createGiottoMulti(list(a = g1, b = g2))
+
+    pd <- pDataDT(mg)
+    expect_true("list_ID" %in% names(pd))
+    # rows tagged consistently with the child they came from
+    expect_identical(sum(pd$list_ID == "a"), 5L)
+    expect_identical(sum(pd$list_ID == "b"), 3L)
+    # list_ID aligns with the cell_ID prefix
+    expect_true(all(startsWith(pd$cell_ID[pd$list_ID == "a"], "a::")))
+    expect_true(all(startsWith(pd$cell_ID[pd$list_ID == "b"], "b::")))
+})
+
 test_that("activeSpatUnit / activeFeatType return per-child vectors", {
     g1 <- .mk_minimal(5, 4)
     g2 <- .mk_minimal(3, 4)


### PR DESCRIPTION
## What

\`.gm_assemble_cell_metadata\` prefixed cell_IDs with the child name but didn't add a sample-origin column. Adds \`dt[, list_ID := nm]\` immediately after the cell_ID prefix step.

## Why

Downstream Giotto tools expect the \`list_ID\` column to identify sample origin. The most direct example: \`runGiottoHarmony\`'s default \`vars_use = "list_ID"\`. Without this column on the assembled multi metadata, harmony integration (and any other tool using \`list_ID\` as the batch covariate) fails on giottoMulti out of the box.

This matches \`joinGiottoObjects\`'s convention, which adds the same \`list_ID = gname\` column.

## Convention alignment

| Source | cell_ID separator | list_ID column |
|---|---|---|
| joinGiottoObjects | \`paste0(gname, "-", cell_ID)\` | \`list_ID = gname\` |
| .gm_assemble_cell_metadata (before) | \`paste(nm, cell_ID, sep = "::")\` | missing |
| .gm_assemble_cell_metadata (after) | \`paste(nm, cell_ID, sep = "::")\` | \`list_ID = nm\` |

The cell_ID separator difference (\`-\` vs \`::\`) is deliberate — \`::\` is the giottoMulti convention locked in by existing tests. The list_ID column is the part that needed to match.

## Test plan
- [x] One new test in test-gmulti.R covers: column present, values match child names, list_ID aligns with cell_ID prefix.
- [x] All 255 gmulti tests pass (248 + 7 expectations under the new test_that).

## Downstream

This unblocks \`runGiottoHarmony(mg, vars_use = "list_ID")\` against a federated giottoMulti, assuming the multi already carries a cross-sample \`@dimension_reduction[["pca"]]\` to integrate.