### PR TITLE
feat: overlay-model cell metadata on giottoMulti

### DIFF
--- a/R/gmulti.R
+++ b/R/gmulti.R
@@ -1256,21 +1256,34 @@ setMethod("getCellMetadata", "giottoMulti", function(gobject,
         .set_default_nesting(gobject, spat_unit, feat_type)
     }
 
-    # Joint slot populated? defer to gAny (view-filter applies)
-    joint <- gobject@cell_metadata[[spat_unit]][[feat_type]]
-    if (inherits(joint, "cellMetaObj")) {
-        return(callNextMethod(gobject,
-            spat_unit = spat_unit, feat_type = feat_type,
-            output = output, copy_obj = copy_obj, set_defaults = FALSE))
-    }
-
-    # Empty — assemble from children with per-child resolved defaults.
-    cm <- .gm_assemble_cell_metadata(gobject,
+    # Overlay model: always assemble base from children (canonical for
+    # per-cell columns + list_ID + prefixed cell_ID). If the multi has
+    # multi-level annotations in @cell_metadata, left-join them over the
+    # base with overlay-wins-on-conflicts semantics. Same shape as
+    # SpatialData's separate annotation tables; allows non-destructive
+    # cell-level scope on the multi to write back via setCellMetadata
+    # without mutating children's metadata.
+    base <- .gm_assemble_cell_metadata(gobject,
         spat_unit = if (nospec_unit) NULL else spat_unit,
         feat_type = if (nospec_feat) NULL else feat_type)
-    cm <- .gm_apply_view(cm, gobject)
-    if (output == "data.table") return(cm[])
-    cm
+    base <- .gm_apply_view(base, gobject)
+
+    overlay <- gobject@cell_metadata[[spat_unit]][[feat_type]]
+    if (inherits(overlay, "cellMetaObj")) {
+        base_dt <- base[]
+        ov_dt <- if (isTRUE(copy_obj)) data.table::copy(overlay[]) else overlay[]
+        ov_cols <- setdiff(names(ov_dt), "cell_ID")
+        if (length(ov_cols) > 0L) {
+            # update join — overlay values override base for matching
+            # cell_IDs; overlay-only columns get added (NA for non-matching).
+            base_dt[ov_dt, on = "cell_ID",
+                (ov_cols) := mget(paste0("i.", ov_cols))]
+        }
+        base[] <- base_dt
+    }
+
+    if (output == "data.table") return(base[])
+    base
 })
 
 #' @rdname getFeatureMetadata

--- a/R/slot_list.R
+++ b/R/slot_list.R
@@ -149,6 +149,16 @@ list_expression_names <- function(gobject,
 #' list_cell_id_names(g)
 #' @export
 list_cell_id_names <- function(gobject) {
+    if (inherits(gobject, "giottoMulti")) {
+        # giottoMulti's own @cell_ID slot stays empty by default;
+        # fall back to the union of children's spat_units so callers
+        # checking "is there any cell info?" get a truthful answer.
+        own <- names(gobject@cell_ID)
+        if (length(own) > 0L) return(own)
+        kids <- unique(unlist(lapply(gobject@objects,
+            function(g) names(g@cell_ID))))
+        return(kids)
+    }
     return(names(gobject@cell_ID))
 }
 

--- a/tests/testthat/test-gmulti.R
+++ b/tests/testthat/test-gmulti.R
@@ -861,3 +861,78 @@ test_that("explicit source class mismatch with children errors", {
         "does not match"
     )
 })
+
+
+# overlay model: multi@cell_metadata as annotation layer over children ----
+
+test_that("multi@cell_metadata empty -> pDataDT returns pure assembly", {
+    g1 <- .mk_minimal(5, 4)
+    g2 <- .mk_minimal(3, 4)
+    mg <- createGiottoMulti(list(a = g1, b = g2))
+    expect_length(mg@cell_metadata, 0L)
+    pd <- pDataDT(mg)
+    expect_true("list_ID" %in% names(pd))
+    expect_identical(nrow(pd), 8L)
+})
+
+test_that("multi-level annotation column overlays children's values", {
+    g1 <- .mk_minimal(5, 4)
+    g2 <- .mk_minimal(3, 4)
+    mg <- createGiottoMulti(list(a = g1, b = g2))
+
+    # Add a multi-level cluster column via setCellMetadata
+    base <- pDataDT(mg)
+    clusters <- data.table::data.table(
+        cell_ID = base$cell_ID,
+        cluster = rep(c("X", "Y"), length.out = nrow(base))
+    )
+    cm <- createCellMetaObj(clusters,
+        spat_unit = "cell", feat_type = "rna")
+    mg <- setCellMetadata(mg, x = cm, verbose = FALSE)
+
+    pd2 <- pDataDT(mg)
+    expect_true("cluster" %in% names(pd2))
+    expect_setequal(pd2$cluster, c("X", "Y"))
+    # list_ID still present from assembly
+    expect_true("list_ID" %in% names(pd2))
+})
+
+test_that("partial overlay coverage NA-fills unmentioned cells", {
+    g1 <- .mk_minimal(5, 4)
+    g2 <- .mk_minimal(3, 4)
+    mg <- createGiottoMulti(list(a = g1, b = g2))
+
+    # overlay covers only child b's cells
+    base <- pDataDT(mg)
+    partial <- data.table::data.table(
+        cell_ID = base$cell_ID[base$list_ID == "b"],
+        b_only_flag = TRUE
+    )
+    cm <- createCellMetaObj(partial,
+        spat_unit = "cell", feat_type = "rna")
+    mg <- setCellMetadata(mg, x = cm, verbose = FALSE)
+
+    pd <- pDataDT(mg)
+    expect_true("b_only_flag" %in% names(pd))
+    # Cells in child b have value, cells in child a are NA
+    expect_true(all(pd$b_only_flag[pd$list_ID == "b"] == TRUE))
+    expect_true(all(is.na(pd$b_only_flag[pd$list_ID == "a"])))
+})
+
+test_that("child standalone view is untouched by multi-level annotations", {
+    g1 <- .mk_minimal(5, 4)
+    g2 <- .mk_minimal(3, 4)
+    mg <- createGiottoMulti(list(a = g1, b = g2))
+
+    cluster_dt <- data.table::data.table(
+        cell_ID = paste0("a::c", 1:5),
+        cluster = "X"
+    )
+    cm <- createCellMetaObj(cluster_dt,
+        spat_unit = "cell", feat_type = "rna")
+    mg <- setCellMetadata(mg, x = cm, verbose = FALSE)
+
+    # Child accessed standalone — no `cluster` column
+    child_a_pd <- pDataDT(mg@objects$a)
+    expect_false("cluster" %in% names(child_a_pd))
+})


### PR DESCRIPTION
## What

Switch \`getCellMetadata(giottoMulti)\` from a wholesale-takeover model to an **overlay model**: always assemble base from children (canonical for per-cell columns + list_ID + prefixed cell_ID), then LEFT-JOIN \`multi@cell_metadata\` over the base. Overlay wins on conflicts.

Same architectural shape as SpatialData's separate annotation tables (per-sample table + joint table).

## Why

The previous switch model meant \`setCellMetadata(multi, x)\` wholesale-replaced the assembled view — once you wrote to the multi, children's metadata stopped contributing. That breaks:

- Multi-level annotations that should layer over children (e.g. harmony cluster labels)
- Non-destructive cell-level subsets (need to write back to only some cells while preserving others)
- The mental model that children are canonical for per-cell data and the multi is an analytical view on top

Overlay model gives us:
- \`setCellMetadata(multi, x)\` writes to multi@cell_metadata via the existing gAny method — no new method needed, the dispatch already works.
- \`pDataDT(multi)\` merges children's view + overlay.
- Partial overlay coverage: cells not in the overlay get NA for overlay-only columns, original child values for shared columns.
- Children's @cell_metadata is never mutated. Standalone child analyses see only the child's own metadata.

The "child metadata can go stale relative to multi overlay" trade-off is the same one SpatialData users live with. Documented as a user-discipline boundary.

## Companion fix

\`list_cell_id_names\` falls back to the union of children's @cell_ID names when called on a giottoMulti whose own @cell_ID is empty. Required because \`setCellMetadata\`'s \`giotto.check_valid\` path consults this function; without the fallback every \`setCellMetadata(multi, ...)\` call trips the "Add expression or spatial information first" check even when children carry that info.

## Test plan
- [x] 4 new tests in test-gmulti.R cover:
  - Empty overlay -> pure assembly read
  - Overlay column visible in pDataDT after setCellMetadata
  - Partial overlay -> NA-fill for non-covered cells
  - Children's standalone view untouched by multi-level annotations
- [x] 273/273 gmulti tests pass (255 -> 273, +18 expectations across the new tests)
- [ ] R CMD check

## Pattern for harmony / leiden / etc.

With this in place, \`runGiottoHarmony(multi, vars_use = "list_ID")\` works end-to-end:
1. \`pDataDT(multi)\` returns assembled view (with list_ID) + any prior overlay
2. harmony reads the joint PCA from \`multi@dimension_reduction\`, runs integration
3. Output dimObj written to \`multi@dimension_reduction[["harmony"]]\` via the standard setter path
4. Downstream cluster annotations land in \`multi@cell_metadata\` overlay via \`addCellMetadata\`-style writes

No changes needed in the upstream Giotto pipeline functions.