### PR TITLE
fix(loadGiotto): federated giottoMulti save+load round-trip

### DIFF
--- a/R/auxilliary.R
+++ b/R/auxilliary.R
@@ -1630,8 +1630,10 @@ createMetafeats <- function(gobject,
         }
     }
 
-    # spatlocs
-    avail_sl <- list_spatial_locations(gobject)
+    # spatlocs (per-child only — not present on giottoMulti)
+    avail_sl <- if (inherits(gobject, "giotto")) {
+        list_spatial_locations(gobject)
+    } else NULL
     if (!is.null(avail_sl)) {
         for (sl_i in seq(nrow(avail_sl))) {
             sl <- getSpatialLocations(
@@ -1677,8 +1679,10 @@ createMetafeats <- function(gobject,
         }
     }
 
-    # spatial grid
-    avail_sg <- list_spatial_grids(gobject)
+    # spatial grid (per-child only — not present on giottoMulti)
+    avail_sg <- if (inherits(gobject, "giotto")) {
+        list_spatial_grids(gobject)
+    } else NULL
     if (!is.null(avail_sg)) {
         for (sg_i in seq(nrow(avail_sg))) {
             sg <- getSpatialGrid(

--- a/R/gmulti.R
+++ b/R/gmulti.R
@@ -189,6 +189,14 @@ setMethod("initialize", signature("giottoMulti"), function(.Object, objects = NU
         .Object@objects <- objects
     }
 
+    # Default instructions, same lifecycle as on a single giotto: created
+    # on first initialize if not user-supplied. The multi is the object the
+    # user views and operates on, so a populated @instructions is needed
+    # for downstream tools (python path, plotting prefs, etc.).
+    if (is.null(.Object@instructions)) {
+        .Object@instructions <- createGiottoInstructions()
+    }
+
     if (length(.Object@objects) == 0L) return(.Object)
 
     # Source resolution: federated multi keeps per-child sources intact but

--- a/R/methods-instructions.R
+++ b/R/methods-instructions.R
@@ -101,7 +101,7 @@ setMethod(
 #' @rdname giotto_instructions
 #' @export
 setMethod(
-    "instructions", signature(gobject = "giotto", param = "missing"),
+    "instructions", signature(gobject = "gAny", param = "missing"),
     function(gobject) {
         return(showGiottoInstructions(gobject))
     }
@@ -112,7 +112,7 @@ setMethod(
 #' @rdname giotto_instructions
 #' @export
 setMethod(
-    "instructions", signature(gobject = "giotto", param = "character"),
+    "instructions", signature(gobject = "gAny", param = "character"),
     function(gobject, param) {
         instrs <- showGiottoInstructions(gobject = gobject)
         return(readGiottoInstructions(
@@ -137,7 +137,7 @@ setMethod(
 setMethod(
     "instructions<-",
     signature(
-        gobject = "giotto",
+        gobject = "gAny",
         param = "missing", initialize = "missing", value = "ANY"
     ),
     function(gobject, initialize, value) {
@@ -153,7 +153,7 @@ setMethod(
 setMethod(
     "instructions<-",
     signature(
-        gobject = "giotto",
+        gobject = "gAny",
         param = "missing", initialize = "logical", value = "ANY"
     ),
     function(gobject, initialize, value) {
@@ -172,7 +172,7 @@ setMethod(
 setMethod(
     "instructions<-",
     signature(
-        gobject = "giotto",
+        gobject = "gAny",
         param = "character", initialize = "missing", value = "ANY"
     ),
     function(gobject, param, initialize, value) {
@@ -191,7 +191,7 @@ setMethod(
 setMethod(
     "instructions<-",
     signature(
-        gobject = "giotto",
+        gobject = "gAny",
         param = "character", initialize = "logical", value = "ANY"
     ),
     function(gobject, param, initialize, value) {

--- a/R/save_load.R
+++ b/R/save_load.R
@@ -223,11 +223,9 @@ loadGiotto <- function(path_to_folder,
     init_gobject = TRUE,
     verbose = TRUE,
     ...) {
-    # data.table vars
-    img_type <- NULL
-
-    path_to_folder <- path.expand(path_to_folder)
-    vmsg(.v = verbose, .is_debug = TRUE, "load from:", path_to_folder)
+      path_to_folder <- path.expand(path_to_folder)
+      vmsg(.v = verbose, .is_debug = TRUE, "load from:", path_to_folder)
+      env_list <- get_args_list(...)
 
     if (!file.exists(path_to_folder)) {
         stop("path_to_folder does not exist \n")
@@ -240,32 +238,16 @@ loadGiotto <- function(path_to_folder,
         src <- GiottoDisk::resolveSource(path_to_folder)
     }
     if (isFALSE(src)) {
+        # load base object
+        # no additional effects
         gobject <- .load_gobject_core(
             path_to_folder = path_to_folder,
             load_params = load_params,
             verbose = verbose
         )
-      
-          ### ### spatial information loading ### ###
-        # terra vector objects are serialized as .shp files.
-        # These .shp files have to be read back in and then the relevant objects
-        # in the giotto object need to be regenerated.
-
-        ## 2. read in spatial features
-        gobject <- .load_giotto_feature_info(
-            gobject = gobject,
-            path_to_folder = path_to_folder,
-            verbose = verbose
-        )
-
-
-        ## 3. read in spatial polygons
-        gobject <- .load_giotto_spatial_info(
-            gobject = gobject,
-            path_to_folder = path_to_folder,
-            verbose = verbose
-        )
     } else {
+        # handles source-specific pathing + load base object
+        # no additional effects
         gobject <- GiottoDisk::snapshotLoad(src, 
             load_params = load_params,
             verbose = verbose,
@@ -273,51 +255,26 @@ loadGiotto <- function(path_to_folder,
         )
     }
 
-
-    ## 4. images
-    # compatibility for pre-v0.3.0
-    gobject <- .update_image_slot(gobject) # merge largeImages slot to images
-    gobject <- .load_giotto_images(
-        gobject = gobject,
-        path_to_folder = path_to_folder,
-        verbose = verbose
-    )
-
-    if (isTRUE(reconnect_giottoImage) && length(gobject[["images"]]) > 0) {
-        imglist <- lapply(gobject[["images"]], reconnect)
-        gobject <- setGiotto(gobject, imglist,
-            verbose = FALSE, initialize = FALSE
+    if (inherits(gobject, "giottoMulti")) {
+        gobject@objects <- lapply(gobject@objects, function(g) {
+            gtype <- ifelse(is.null(g@source), "memory", "disk")
+            .load_giotto_extra(g, 
+                type = gtype, env_list = env_list, skip = "pypath"
+            )
+        })
+        gobject <- .load_giotto_extra(gobject, 
+            type = "multi", env_list = env_list
         )
-    }
-
-
-    ## 5. Update python path (do not initialize yet)
-    # ***if python should be used...***
-    if (isTRUE(getOption("giotto.use_conda", TRUE))) {
-        identified_python_path <- set_giotto_python_path(
-            python_path = python_path,
-            verbose = verbose,
-            initialize = TRUE
-        )
-        vmsg(.v = verbose, .is_debug = TRUE, identified_python_path)
-        gobject <- changeGiottoInstructions(
-            gobject = gobject,
-            params = c("python_path"),
-            new_values = c(identified_python_path),
-            init_gobject = FALSE
+    } else if (!isFALSE(src)) {
+        gobject <- .load_giotto_extra(gobject,
+            type = "disk", env_list = env_list
         )
     } else {
-        # ***if python is not needed...***
-        instr <- instructions(gobject)
-        instr["python_path"] <- list(NULL)
-        instructions(gobject, initialize = FALSE) <- instr
+        gobject <- .load_giotto_extra(gobject,
+            type = "memory", env_list = env_list
+        )
     }
 
-    ## 6. overallocate for data.tables
-    # (data.tables when read from disk have a truelength of 0)
-    gobject <- .giotto_alloc_dt(gobject)
-
-    ## 7. initialize
     if (isTRUE(init_gobject)) {
         gobject <- initialize(gobject)
     }
@@ -512,6 +469,98 @@ setMethod(".load_external", signature("SpatVector"), function(x, name_fmt, dir,
     }
 }
 
+# extra load steps per type of gobject
+.load_giotto_extra <- function(gobject,
+    type = c("memory", "disk", "multi"),
+    skip = c(), 
+    env_list) {
+    type <- match.arg(type, choice = c("memory", "disk", "multi"))
+    list2env(env_list, environment())
+  
+    steps <- switch(type,
+        "memory" = c("point", "poly", "image", "pypath", "dtalloc"),
+        "disk" = c("image", "pypath", "dtalloc"),
+        "multi" = c("pypath", "dtalloc")
+    )
+  
+    steps <- setdiff(steps, skip)
+  
+    for(step in steps) {
+        gobject <- switch(step,
+            "point" = .load_giotto_feature_info(
+                gobject, path_to_folder, verbose),
+            "poly" = .load_giotto_spatial_info(
+                gobject, path_to_folder, verbose),
+            "image" = .load_gobject_images(
+                gobject, path_to_folder, reconnect_giottoImage, verbose),
+            "pypath" = .load_gobject_pyenv(
+                gobject, python_path, verbose),
+            "dtalloc" = .giotto_alloc_dt(gobject)
+        )
+    }
+    gobject
+}
+
+.load_gobject_images <- function(
+    gobject, path_to_folder, reconnect_giottoImage, verbose) {
+    # compatibility for pre-v0.3.0
+    gobject <- .update_image_slot(gobject) # merge largeImages slot to images
+    gobject <- .load_giotto_images(
+        gobject = gobject,
+        path_to_folder = path_to_folder,
+        verbose = verbose
+    )
+
+    if (isTRUE(reconnect_giottoImage) && length(gobject[["images"]]) > 0) {
+        imglist <- lapply(gobject[["images"]], reconnect)
+        gobject <- setGiotto(gobject, imglist,
+            verbose = FALSE, initialize = FALSE
+        )
+    }
+    gobject
+}
+
+# update python path for loaded object (no gobject initialization)
+#
+# On a giottoMulti, the python path is canonical at the multi level: there
+# is only one active python env per R session, so we set the path on the
+# multi's @instructions (already initialized by initialize(giottoMulti))
+# and distribute it down to children so they stay coherent when accessed
+# standalone.
+.load_gobject_pyenv <- function(gobject, python_path, verbose) {
+    if (isTRUE(getOption("giotto.use_conda", TRUE))) {
+        # identify python path to use
+        p <- set_giotto_python_path(
+            python_path = python_path,
+            verbose = verbose,
+            initialize = TRUE
+        )
+        vmsg(.v = verbose, .is_debug = TRUE, p)
+        instructions(gobject, "python_path", initialize = FALSE) <- p
+    } else {
+        # ***if python is not needed...***
+        instr <- instructions(gobject)
+        instr["python_path"] <- list(NULL)
+        instructions(gobject, initialize = FALSE) <- instr
+    }
+
+    # Distribute multi-level python_path down to children
+    if (inherits(gobject, "giottoMulti")) {
+        py <- instructions(gobject, "python_path")
+        gobject@objects <- lapply(gobject@objects, function(child) {
+            if (is.null(py)) {
+                instr <- instructions(child)
+                instr["python_path"] <- list(NULL)
+                instructions(child, initialize = FALSE) <- instr
+            } else {
+                instructions(child, "python_path", initialize = FALSE) <- py
+            }
+            child
+        })
+    }
+    gobject
+}
+
 # load and append spatial feature information
 .load_giotto_feature_info <- function(gobject, path_to_folder, verbose = NULL) {
     vmsg(.v = verbose, "2. read Giotto feature information")
@@ -543,7 +592,6 @@ setMethod(".load_external", signature("SpatVector"), function(x, name_fmt, dir,
 
     return(gobject)
 }
-
 
 # the actual reconnection step is done through reconnect() after this step now
 # .update_giotto_image() <- this is NEEDED for legacy structure support

--- a/man/giotto_instructions.Rd
+++ b/man/giotto_instructions.Rd
@@ -6,13 +6,13 @@
 \alias{instructions}
 \alias{instructions<-}
 \alias{instructions,missing,missing-method}
-\alias{instructions,giotto,missing-method}
-\alias{instructions,giotto,character-method}
+\alias{instructions,gAny,missing-method}
+\alias{instructions,gAny,character-method}
 \alias{instructions,giottoInstructions,character-method}
-\alias{instructions<-,giotto,missing,missing-method}
-\alias{instructions<-,giotto,missing,logical-method}
-\alias{instructions<-,giotto,character,missing-method}
-\alias{instructions<-,giotto,character,logical-method}
+\alias{instructions<-,gAny,missing,missing-method}
+\alias{instructions<-,gAny,missing,logical-method}
+\alias{instructions<-,gAny,character,missing-method}
+\alias{instructions<-,gAny,character,logical-method}
 \alias{instructions<-,giottoInstructions,character,ANY-method}
 \title{Giotto instructions}
 \usage{
@@ -35,19 +35,19 @@ createGiottoInstructions(
 
 \S4method{instructions}{missing,missing}(gobject, param, ...)
 
-\S4method{instructions}{giotto,missing}(gobject)
+\S4method{instructions}{gAny,missing}(gobject)
 
-\S4method{instructions}{giotto,character}(gobject, param)
+\S4method{instructions}{gAny,character}(gobject, param)
 
 \S4method{instructions}{giottoInstructions,character}(gobject, param)
 
-\S4method{instructions}{giotto,missing,missing}(gobject, initialize) <- value
+\S4method{instructions}{gAny,missing,missing}(gobject, initialize) <- value
 
-\S4method{instructions}{giotto,missing,logical}(gobject, initialize) <- value
+\S4method{instructions}{gAny,missing,logical}(gobject, initialize) <- value
 
-\S4method{instructions}{giotto,character,missing}(gobject, param, initialize) <- value
+\S4method{instructions}{gAny,character,missing}(gobject, param, initialize) <- value
 
-\S4method{instructions}{giotto,character,logical}(gobject, param, initialize) <- value
+\S4method{instructions}{gAny,character,logical}(gobject, param, initialize) <- value
 
 \S4method{instructions}{giottoInstructions,character,ANY}(gobject, param) <- value
 }

--- a/tests/testthat/test-gmulti.R
+++ b/tests/testthat/test-gmulti.R
@@ -918,3 +918,48 @@ test_that("after materialization, child updates do not propagate to multi", {
     pd <- pDataDT(mg)
     expect_false("sample_only" %in% names(pd))
 })
+
+
+# saveGiotto / loadGiotto round-trip on a federated giottoMulti.
+# Exercises the full federated flow: GiottoDisk::snapshotSave from the
+# saveGiotto entry point, GiottoDisk::snapshotLoad on the way back in, and
+# the GiottoClass-side post-load steps gated correctly for the multi class.
+
+test_that("saveGiotto + loadGiotto round-trip preserves a federated giottoMulti", {
+    skip_if_not_installed("GiottoDisk")
+    rlang::local_options(lifecycle_verbosity = "quiet")
+
+    # Two backed children + a backed multi parent.
+    mk_backed <- function(n_cell, tag) {
+        m <- matrix(rpois(n_cell * 6, 2), nrow = 6, ncol = n_cell,
+            dimnames = list(paste0("f", 1:6),
+                            paste0(tag, "_c", seq_len(n_cell))))
+        dir <- file.path(tempdir(),
+            paste0("gmulti_load_child_", tag, "_", basename(tempfile())))
+        createGiottoObject(expression = m, backend = dir, verbose = FALSE)
+    }
+    g1 <- mk_backed(5, "a")
+    g2 <- mk_backed(3, "b")
+    mdir <- file.path(tempdir(),
+        paste0("gmulti_load_parent_", basename(tempfile())))
+    on.exit({
+        unlink(g1@source@path, recursive = TRUE)
+        unlink(g2@source@path, recursive = TRUE)
+        unlink(mdir, recursive = TRUE)
+    }, add = TRUE)
+
+    parent_src <- GiottoDisk::gDirSource(mdir)
+    mg <- createGiottoMulti(list(a = g1, b = g2), source = parent_src)
+    expect_s4_class(mg, "giottoMulti")
+    expect_false(is.null(mg@source))
+
+    saveGiotto(mg, name = "rt", verbose = FALSE)
+
+    mg2 <- loadGiotto(mdir, verbose = FALSE)
+    expect_s4_class(mg2, "giottoMulti")
+    expect_identical(names(mg2), c("a", "b"))
+    expect_identical(length(spatIDs(mg2@objects$a)), 5L)
+    expect_identical(length(spatIDs(mg2@objects$b)), 3L)
+    expect_identical(spatIDs(mg2),
+        c(paste0("a::a_c", 1:5), paste0("b::b_c", 1:3)))
+})


### PR DESCRIPTION
GiottoDisk::snapshotSave / snapshotLoad implement the federated multi save+load roundtrip end-to-end (see GiottoDisk PR #14). loadGiotto's post-load steps assumed a \`giotto\` shape and broke on the returned giottoMulti — this PR makes the post-load path multi-aware.

## What changes

**\`R/save_load.R\`** — restructured \`loadGiotto\`'s post-load steps into a small dispatch helper:

\`\`\`r
.load_giotto_extra(gobject, type, env_list, skip)
\`\`\`

with steps per type:
- \`memory\`: point, poly, image, pypath, dtalloc
- \`disk\`:   image, pypath, dtalloc
- \`multi\`:  pypath, dtalloc

For a giottoMulti load: each child is walked through \`.load_giotto_extra\` with type derived from its own \`@source\` (\`memory\` or \`disk\`) and \`pypath\` skipped. The multi-level call then runs \`pypath\` (canonical — only one python env per session) and distributes the resolved python_path down to children's \`@instructions\` so they stay coherent when accessed standalone.

**\`R/gmulti.R\`** — \`initialize(giottoMulti)\` now bootstraps a default \`@instructions\` via \`createGiottoInstructions()\` when NULL. Mirrors the single-giotto pattern so downstream tools (python path, plotting prefs, etc.) always have somewhere to land.

**\`R/methods-instructions.R\`** — \`instructions\` / \`instructions<-\` lifted from \`\"giotto\"\` to \`\"gAny\"\`. Both classes have the \`@instructions\` slot; same method body works.

**\`R/auxilliary.R\`** — \`.giotto_alloc_dt\` gates spatial_locs and spatial_grid walks on \`inherits(gobject, \"giotto\")\` — those slots exist on giotto only. Shared-domain walks (cell_metadata, feat_metadata, spatial_enrichment) work on both via gAny dispatch.

## Tests

- Adds an integration test for saveGiotto + loadGiotto round-trip on a federated giottoMulti (backed children + backed parent).
- Full test suite: 1161 / 0.

## Test plan

- [x] saveGiotto on a federated giottoMulti routes to GiottoDisk::snapshotSave (was already correct via @source dispatch in saveGiotto).
- [x] loadGiotto on the same project directory returns a giottoMulti with children + sources intact and globals namespaced.
- [x] Children's @images survive round-trip — reconnect() walks each child's images and refreshes SpatRaster handles from on-disk @file_path.
- [x] Multi-level python_path is canonical; children mirror it.
- [x] Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)