### PR TITLE
deprecate: expression_matrix_class across createGiottoObject + read helpers

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -74,8 +74,7 @@ NULL
 #' from \code{\link{createGiottoInstructions}}
 #' @param cores how many cores or threads to use to read data if paths are
 #' provided
-#' @param expression_matrix_class class of expression matrix to
-#' use (e.g. 'dgCMatrix', 'DelayedArray')
+#' @param expression_matrix_class deprecated. See `?createExprObj` for details
 #' @param h5_file path to h5 file
 #' @param verbose be verbose when building Giotto object
 #' @returns `giotto` object
@@ -218,7 +217,7 @@ createGiottoObject <- function(expression,
     instructions = NULL,
     cores = determine_cores(),
     raw_exprs = NULL,
-    expression_matrix_class = c("dgCMatrix", "DelayedArray"),
+    expression_matrix_class = deprecated(),
     h5_file = NULL,
     verbose = FALSE) {
     debug_msg <- FALSE # for reading debug help
@@ -234,6 +233,13 @@ createGiottoObject <- function(expression,
             )
         )
         images <- c(images, largeImages)
+    }
+
+    if (is_present(expression_matrix_class)) {
+        warning(sprintf(
+            "[createGiottoObject] param '%s' is deprecated",
+            "expression_matrix_class"),
+        call. = FALSE)
     }
 
     # create minimum giotto
@@ -345,8 +351,7 @@ createGiottoObject <- function(expression,
             sparse = TRUE,
             cores = cores,
             default_feat_type = expression_feat,
-            verbose = debug_msg,
-            expression_matrix_class = expression_matrix_class
+            verbose = debug_msg
         )
         ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ###
         ## evaluate if h5_file exists

--- a/R/data_evaluation.R
+++ b/R/data_evaluation.R
@@ -78,9 +78,6 @@ evaluate_input <- function(type, x, ...) {
 #' @param inputmatrix inputmatrix to evaluate
 #' @param sparse create sparse matrix (default = TRUE)
 #' @param cores how many cores to use
-#' @param expression_matrix_class `character` (optional). Matrix
-#'   representation to convert to. If left as NULL, no conversions will
-#'   be attempted
 #' @details The inputmatrix can be a matrix, sparse matrix, data.frame,
 #' data.table or path to any of these.
 #' @keywords internal

--- a/R/data_input.R
+++ b/R/data_input.R
@@ -10,8 +10,7 @@
 #' @param path path to the expression matrix
 #' @param cores number of cores to use
 #' @param transpose transpose matrix
-#' @param expression_matrix_class class of expression matrix to
-#' use (e.g. 'dgCMatrix', 'DelayedArray')
+#' @param expression_matrix_class deprecated. See `?createExprObj` for details
 #' @inheritParams data_access_params
 #' @details The expression matrix needs to have both unique column names and
 #' row names
@@ -28,18 +27,16 @@ readExprMatrix <- function(
         cores = determine_cores(),
         transpose = FALSE,
         feat_type = "rna",
-        expression_matrix_class = c(
-            "dgCMatrix",
-            "DelayedArray",
-            "dbSparseMatrix"
-        )) {
+        expression_matrix_class = deprecated()) {
     # check if path is a character vector and exists
     if (!is.character(path)) stop("path needs to be character vector")
     if (!file.exists(path)) stop("the path: ", path, " does not exist")
 
-    expression_matrix_class <- match.arg(expression_matrix_class)
-    if (identical(expression_matrix_class, "dbSparseMatrix")) {
-        stop("File conversion to dbMatrix is not yet supported")
+    if (is_present(expression_matrix_class)) {
+        warning(sprintf(
+            "[readExprMatrix] param '%s' is deprecated",
+            "expression_matrix_class"),
+        call. = FALSE)
     }
 
     data.table::setDTthreads(threads = cores)
@@ -59,10 +56,6 @@ readExprMatrix <- function(
 
     if (isTRUE(transpose)) {
         spM <- t_flex(spM)
-    }
-
-    if (expression_matrix_class[1] == "DelayedArray") {
-        spM <- DelayedArray::DelayedArray(spM)
     }
 
     return(spM)
@@ -85,8 +78,7 @@ readExprMatrix <- function(
 #' @param data_list (nested) list of expression input data
 #' @param sparse (boolean, default = TRUE) read matrix data in a sparse manner
 #' @param cores number of cores to use
-#' @param expression_matrix_class class of expression matrix to
-#' use (e.g. 'dgCMatrix', 'DelayedArray')
+#' @param expression_matrix_class deprecated. See `?createExprObj` for details
 #' @inheritParams read_data_params
 #' @returns exprObj
 #' @details
@@ -120,15 +112,20 @@ readExprData <- function(data_list,
     default_feat_type = NULL,
     verbose = TRUE,
     provenance = NULL,
-    expression_matrix_class = c("dgCMatrix", "DelayedArray")) {
+    expression_matrix_class = deprecated()) {
+    if (is_present(expression_matrix_class)) {
+        warning(sprintf(
+            "[readExprData] param '%s' is deprecated",
+            "expression_matrix_class"),
+        call. = FALSE)
+    }
     .read_expression_data(
         expr_list = data_list,
         sparse = sparse,
         cores = cores,
         default_feat_type = default_feat_type,
         verbose = verbose,
-        provenance = provenance,
-        expression_matrix_class = expression_matrix_class
+        provenance = provenance
     )
 }
 
@@ -141,8 +138,7 @@ readExprData <- function(data_list,
     default_spat_unit = NULL,
     default_feat_type = NULL,
     verbose = TRUE,
-    provenance = NULL,
-    expression_matrix_class = c("dgCMatrix", "DelayedArray")) {
+    provenance = NULL) {
     # import box characters
     ch <- box_chars()
 
@@ -335,8 +331,7 @@ readExprData <- function(data_list,
                         } else {
                             provenance
                         }, # assumed
-                        misc = NULL,
-                        expression_matrix_class = expression_matrix_class
+                        misc = NULL
                     )
                 )
             }

--- a/man/create_giotto.Rd
+++ b/man/create_giotto.Rd
@@ -28,7 +28,7 @@ createGiottoObject(
   instructions = NULL,
   cores = determine_cores(),
   raw_exprs = NULL,
-  expression_matrix_class = c("dgCMatrix", "DelayedArray"),
+  expression_matrix_class = deprecated(),
   h5_file = NULL,
   verbose = FALSE
 )
@@ -108,8 +108,7 @@ provided}
 
 \item{raw_exprs}{deprecated, use expression}
 
-\item{expression_matrix_class}{class of expression matrix to
-use (e.g. 'dgCMatrix', 'DelayedArray')}
+\item{expression_matrix_class}{deprecated. See \code{?createExprObj} for details}
 
 \item{h5_file}{path to h5 file}
 

--- a/man/readExprData.Rd
+++ b/man/readExprData.Rd
@@ -11,7 +11,7 @@ readExprData(
   default_feat_type = NULL,
   verbose = TRUE,
   provenance = NULL,
-  expression_matrix_class = c("dgCMatrix", "DelayedArray")
+  expression_matrix_class = deprecated()
 )
 }
 \arguments{
@@ -27,8 +27,7 @@ readExprData(
 
 \item{provenance}{(optional) provenance information}
 
-\item{expression_matrix_class}{class of expression matrix to
-use (e.g. 'dgCMatrix', 'DelayedArray')}
+\item{expression_matrix_class}{deprecated. See \code{?createExprObj} for details}
 }
 \value{
 exprObj

--- a/man/readExprMatrix.Rd
+++ b/man/readExprMatrix.Rd
@@ -9,7 +9,7 @@ readExprMatrix(
   cores = determine_cores(),
   transpose = FALSE,
   feat_type = "rna",
-  expression_matrix_class = c("dgCMatrix", "DelayedArray", "dbSparseMatrix")
+  expression_matrix_class = deprecated()
 )
 }
 \arguments{
@@ -21,8 +21,7 @@ readExprMatrix(
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
-\item{expression_matrix_class}{class of expression matrix to
-use (e.g. 'dgCMatrix', 'DelayedArray')}
+\item{expression_matrix_class}{deprecated. See \code{?createExprObj} for details}
 }
 \value{
 sparse matrix


### PR DESCRIPTION
\`expression_matrix_class\` was already deprecated in \`createExprObj\` but still had real defaults on \`createGiottoObject\`, \`readExprData\`, and \`readExprMatrix\`. \`createGiottoObject\` forwarded its default through \`readExprData\` → \`.read_expression_data\` → \`createExprObj\`, where \`is_present()\` matched and emitted the deprecation warning on every default \`createGiottoObject\` call. The test suite was generating ~3000 of these warnings per run as a result.

## What changes

Same pattern as the existing \`createExprObj\` deprecation, applied to the rest of the chain:

- **\`createGiottoObject\`** (R/create.R): default → \`deprecated()\`, \`is_present()\` warning, no longer forwards \`expression_matrix_class\` to \`readExprData\`.
- **\`readExprData\`** (R/data_input.R): same.
- **\`readExprMatrix\`** (R/data_input.R): same. The \`DelayedArray\` and \`dbSparseMatrix\` branches are removed — the function now always returns the default sparse class. Acceptable behavior change for a deprecated parameter; the warning surfaces it.
- **\`.read_expression_data\`** (internal): drops the param entirely. No external callers; no longer plumbed through.
- **\`.evaluate_expr_matrix\`** doc: stale \`@param expression_matrix_class\` block removed (the function signature never had this parameter).

## Tests

Full suite: **967 / 0**. Warning count dropped from ~4700 to 1449 with this cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)