### PR TITLE
feat: auto-detect cell_ID/feat_ID column in metadata setters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,26 @@
+# GiottoClass 0.5.2
+
+## changes
+- shared-domain and spatial-domain accessors promoted to S4 generics on `signature("giotto")` — `getCellMetadata` / `setCellMetadata`, `getFeatureMetadata` / `setFeatureMetadata`, `getExpression` / `setExpression`, `getMultiomics` / `setMultiomics`, `getDimReduction` / `setDimReduction`, `getNearestNetwork` / `setNearestNetwork`, `getSpatialEnrichment` / `setSpatialEnrichment`, `getSpatialLocations` / `setSpatialLocations`, `getSpatialNetwork` / `setSpatialNetwork`, `getPolygonInfo` / `setPolygonInfo`, `getFeatureInfo` / `setFeatureInfo`, `getGiottoImage` / `setGiottoImage`. Per-accessor internal/external split helpers (`.external_accessor_*` sentinel pattern) inlined into the public setters.
+- `overlapPointDT[i]` / `[, j]` default flipped from `ids = TRUE` → `ids = FALSE`. Default single-axis subset now returns an `overlapPointDT` subset object (matching `overlapIntensityDT` and `SpatVector`). The integer-index selection form is still available via `ovlp[i, ids = TRUE]`.
+
+## new
+- `spatRelate()` generic — filter-form complement to `relate()`: returns `x` narrowed by a spatial predicate rather than a relation matrix. Eager method on `(giottoSpatial, giottoSpatial)` wraps `relate() + subset`; the on-disk lazy form lives in GiottoDisk via methods on `parquetGeomBase`.
+
+## bug fixes
+- fix "unused argument (ids = FALSE)" when subsetting a `giottoPolygon` object
+- skip 0-entry `giottoPoints` in subset paths
+- documentation fix in `methods-extract`
+
+## enhancements
+- `addCellMetadata()` and `addFeatMetadata()` now auto-detect a `cell_ID` /
+  `feat_ID` column on `new_metadata` (including the column auto-added from a
+  named vector) and route through key-based merge regardless of the caller's
+  `by_column` value. Positional `cbind` is fragile when input row order does
+  not match metadata row order; the key-based path is safe by construction.
+  Positional input without a key column still works for backwards compatibility
+  but now emits a warning so callers can opt in to safe alignment.
+
 # GiottoClass 0.5.1 (2026/05/14)
 
 ## changes

--- a/R/auxilliary.R
+++ b/R/auxilliary.R
@@ -505,6 +505,24 @@ addCellMetadata <- function(gobject,
         column_cell_ID <- "cell_ID"
     }
 
+    # 2b. Auto-detect key-based input. When new_metadata carries a
+    # column_cell_ID column (either supplied directly as a data.table /
+    # data.frame, or auto-added from a named vector above), route through
+    # the key-based merge path regardless of the caller's by_column value.
+    # Positional cbind is fragile whenever input row order doesn't match
+    # cell_metadata row order; the key-based path is safe by construction.
+    # When no key column is present the original positional path still
+    # runs, but with a warning so callers can opt in to safe alignment.
+    has_key <- column_cell_ID %in% colnames(new_metadata)
+    if (has_key) {
+        by_column <- TRUE
+    } else if (!isTRUE(by_column)) {
+        warning("addCellMetadata: input has no '", column_cell_ID,
+            "' column / names; falling back to positional cbind. Pass a ",
+            "named vector or a table with a '", column_cell_ID,
+            "' column for key-based alignment.", call. = FALSE)
+    }
+
 
     # 3. combine with existing metadata
     # get old and new meta colnames that are not the ID col
@@ -684,6 +702,24 @@ addFeatMetadata <- function(gobject,
     # If no specific column_feat_ID is provided, assume "feat_ID"
     if (is.null(column_feat_ID)) {
         column_feat_ID <- "feat_ID"
+    }
+
+    # 3b. Auto-detect key-based input. When new_metadata carries a
+    # column_feat_ID column (either supplied directly as a data.table /
+    # data.frame, or auto-added from a named vector above), route through
+    # the key-based merge path regardless of the caller's by_column value.
+    # Positional cbind is fragile whenever input row order doesn't match
+    # feat_metadata row order; the key-based path is safe by construction.
+    # When no key column is present the original positional path still
+    # runs, but with a warning so callers can opt in to safe alignment.
+    has_key <- column_feat_ID %in% colnames(new_metadata)
+    if (has_key) {
+        by_column <- TRUE
+    } else if (!isTRUE(by_column)) {
+        warning("addFeatMetadata: input has no '", column_feat_ID,
+            "' column / names; falling back to positional cbind. Pass a ",
+            "named vector or a table with a '", column_feat_ID,
+            "' column for key-based alignment.", call. = FALSE)
     }
 
 

--- a/tests/testthat/test_03_accessors.R
+++ b/tests/testthat/test_03_accessors.R
@@ -993,9 +993,12 @@ describe("addCellMetadata()", {
             "chars" = sample(LETTERS, size = length(ids), replace = TRUE)
         )
 
-        am_giotto <- addCellMetadata(
-            giotto_object,
-            new_metadata = dt_no_id
+        expect_warning(
+            am_giotto <- addCellMetadata(
+                giotto_object,
+                new_metadata = dt_no_id
+            ),
+            regexp = "no 'cell_ID' column"
         )
 
         res <- pDataDT(am_giotto)
@@ -1016,9 +1019,12 @@ describe("addCellMetadata()", {
 
         chars <- sample(LETTERS, size = length(ids), replace = TRUE)
 
-        am_giotto <- addCellMetadata(
-            giotto_object,
-            new_metadata = chars
+        expect_warning(
+            am_giotto <- addCellMetadata(
+                giotto_object,
+                new_metadata = chars
+            ),
+            regexp = "no 'cell_ID' column"
         )
 
         res <- pDataDT(am_giotto)
@@ -1061,9 +1067,12 @@ describe("addCellMetadata()", {
 
         factors <- factor(sample(LETTERS, size = length(ids), replace = TRUE))
 
-        am_giotto <- addCellMetadata(
-            giotto_object,
-            new_metadata = factors
+        expect_warning(
+            am_giotto <- addCellMetadata(
+                giotto_object,
+                new_metadata = factors
+            ),
+            regexp = "no 'cell_ID' column"
         )
 
         res <- pDataDT(am_giotto)
@@ -1096,6 +1105,52 @@ describe("addCellMetadata()", {
         checkmate:: expect_factor(res$factors2) # values retain type
         # check that start meta order is the same as end
         expect_identical(original_order, res$cell_ID)
+    })
+
+    it("auto-detects cell_ID column and merges by key under default by_column", {
+        # When new_metadata carries a cell_ID column, the setter should
+        # route through the key-based merge regardless of `by_column`.
+        # Guards against silent positional misalignment when the caller's
+        # row order doesn't match cell_metadata row order.
+        ids <- spatIDs(giotto_object)
+        original_order <- spatIDs(getCellMetadata(giotto_object))
+
+        dt_keyed <- data.table::data.table(
+            "cell_ID" = ids,
+            "id_check" = ids,
+            "random" = rnorm(length(ids))
+        )
+        # scramble row order — only the cell_ID key keeps alignment honest
+        dt_keyed <- dt_keyed[sample(1:.N)]
+
+        # Note: NO `by_column = TRUE` passed. Auto-detect should promote.
+        am_giotto <- expect_silent(addCellMetadata(
+            giotto_object,
+            new_metadata = dt_keyed
+        ))
+
+        res <- pDataDT(am_giotto)
+
+        # Auto-detect must have routed through key-based merge:
+        # id_check values must follow cell_ID order, not input row order.
+        expect_identical(res$cell_ID, res$id_check)
+        expect_identical(original_order, res$cell_ID)
+        expect_true("random" %in% colnames(res))
+    })
+
+    it("warns when DF / vector input has no cell_ID column", {
+        ids <- spatIDs(giotto_object)
+        # Positional input — should still work but emit a warning so the
+        # caller can opt in to key-based alignment.
+        expect_warning(addCellMetadata(
+            giotto_object,
+            new_metadata = data.table::data.table(x = rnorm(length(ids)))
+        ), regexp = "no 'cell_ID' column")
+
+        expect_warning(addCellMetadata(
+            giotto_object,
+            new_metadata = rnorm(length(ids))
+        ), regexp = "no 'cell_ID' column")
     })
 
 
@@ -1167,9 +1222,12 @@ describe("addFeatMetadata()", {
             "chars" = sample(LETTERS, size = length(ids), replace = TRUE)
         )
 
-        am_giotto <- addFeatMetadata(
-            giotto_object,
-            new_metadata = dt_no_id
+        expect_warning(
+            am_giotto <- addFeatMetadata(
+                giotto_object,
+                new_metadata = dt_no_id
+            ),
+            regexp = "no 'feat_ID' column"
         )
 
         res <- fDataDT(am_giotto)
@@ -1190,9 +1248,12 @@ describe("addFeatMetadata()", {
 
         chars <- sample(LETTERS, size = length(ids), replace = TRUE)
 
-        am_giotto <- addFeatMetadata(
-            giotto_object,
-            new_metadata = chars
+        expect_warning(
+            am_giotto <- addFeatMetadata(
+                giotto_object,
+                new_metadata = chars
+            ),
+            regexp = "no 'feat_ID' column"
         )
 
         res <- fDataDT(am_giotto)
@@ -1235,9 +1296,12 @@ describe("addFeatMetadata()", {
 
         factors <- factor(sample(LETTERS, size = length(ids), replace = TRUE))
 
-        am_giotto <- addFeatMetadata(
-            giotto_object,
-            new_metadata = factors
+        expect_warning(
+            am_giotto <- addFeatMetadata(
+                giotto_object,
+                new_metadata = factors
+            ),
+            regexp = "no 'feat_ID' column"
         )
 
         res <- fDataDT(am_giotto)
@@ -1270,6 +1334,45 @@ describe("addFeatMetadata()", {
         checkmate::expect_factor(res$factors2) # values retain type
         # check that start meta order is the same as end
         expect_identical(original_order, res$feat_ID)
+    })
+
+    it("auto-detects feat_ID column and merges by key under default by_column", {
+        # Mirror of the addCellMetadata auto-detect test. When
+        # new_metadata carries a feat_ID column, the setter should route
+        # through the key-based merge regardless of `by_column`.
+        ids <- featIDs(giotto_object)
+        original_order <- featIDs(getFeatureMetadata(giotto_object))
+
+        dt_keyed <- data.table::data.table(
+            "feat_ID" = ids,
+            "id_check" = ids,
+            "random" = rnorm(length(ids))
+        )
+        dt_keyed <- dt_keyed[sample(1:.N)]
+
+        am_giotto <- expect_silent(addFeatMetadata(
+            giotto_object,
+            new_metadata = dt_keyed
+        ))
+
+        res <- fDataDT(am_giotto)
+
+        expect_identical(res$feat_ID, res$id_check)
+        expect_identical(original_order, res$feat_ID)
+        expect_true("random" %in% colnames(res))
+    })
+
+    it("warns when DF / vector input has no feat_ID column", {
+        ids <- featIDs(giotto_object)
+        expect_warning(addFeatMetadata(
+            giotto_object,
+            new_metadata = data.table::data.table(x = rnorm(length(ids)))
+        ), regexp = "no 'feat_ID' column")
+
+        expect_warning(addFeatMetadata(
+            giotto_object,
+            new_metadata = rnorm(length(ids))
+        ), regexp = "no 'feat_ID' column")
     })
 
 })


### PR DESCRIPTION
## Summary

- `addCellMetadata()` and `addFeatMetadata()` now route through the key-based merge path whenever `new_metadata` carries a `cell_ID` / `feat_ID` column (either supplied directly as a data.table / data.frame, or auto-added from a named vector). The caller's `by_column` value is overridden when a key is present.
- Positional input without a key column still runs the original `cbind` path for backwards compatibility but emits a warning so callers can opt in to safe alignment.
- Closes a silent-misalignment risk when caller row order does not match metadata row order — particularly load-bearing for joint metadata on multi-sample workflows but defensive on single-giotto too.

## Why

Positional `cbind` is fragile whenever the caller's row order doesn't match metadata row order. The metadata setters already supported the safe path (`by_column = TRUE` + `column_cell_ID`), but the default was positional. This change makes the safe path the default whenever a key column is present, while keeping back-compat for legacy positional callers.

## Notes

- Also regenerates `man/overlapPointDT-class.Rd` and `man/spatRelate.Rd` to sync with roxygen sources that drifted on `dev` (from `fedfa62e` — `ids` default flip — and the spatRelate work).

## Test plan

- [x] Existing positional-path tests wrapped in `expect_warning` (they now emit the new warning by design).
- [x] New tests cover auto-detect with scrambled key + warn-on-no-key for both setters.
- [x] `devtools::test()` full suite: FAIL 0 | PASS 998.