### PR TITLE
refactor(accessors): widen S4 generic signatures + drop match.call magic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,8 +31,26 @@
 - `getExpression` adopts `name` as the canonical formal alongside
   `values` (now a back-compat alias); they error if both supplied and
   differ.
-- `image_type` formal removed from `getGiottoImage()` and `setGiottoImage()`
-  — already documented as deprecated and unused in body.
+- accessor generic formals aligned to one shared contract. Three generics
+  deviated from it, which mattered once the formals moved onto the generics
+  (S4 requires methods to match the generic's shared formal names and order,
+  so the odd ones out could not be written against the common contract):
+  `setMultiomics(result=)` and `setGiottoImage(image=)` are now `x` like every
+  other setter, and `getPolygonInfo(polygon_name=)` is now `name`. The old
+  names remain as deprecated aliases via `deprecate_param()` and continue to
+  work with a warning. Positional calls are unaffected. Following the existing
+  convention (`calculateOverlap(spatial_info)`, `getExpression(values)`), the
+  aliases live on the methods only and reach them through the generic's
+  `...`, so dispatch signatures are unchanged.
+- `image_type` formal removed from `getGiottoImage()`, `setGiottoImage()`,
+  `plotGiottoImage()`, and `distGiottoImage()`. The param had been
+  deprecated for a long time and was a no-op in all four: the accessors
+  never read it, `plotGiottoImage()` overwrote any supplied value by
+  inspecting the class of the fetched image, and `distGiottoImage()`
+  accepted only its default `"largeImage"`. Image class is determined from
+  the object itself. Note this does not affect the `img_type` argument of
+  `list_images()` / `list_images_names()`, which is a working filter and
+  is retained.
 
 # GiottoClass 0.5.1 (2026/05/14)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,19 @@
   not match metadata row order; the key-based path is safe by construction.
   Positional input without a key column still works for backwards compatibility
   but now emits a warning so callers can opt in to safe alignment.
+- Slot-accessor S4 generics widened with contract-stable formals
+  (`spat_unit`, `feat_type`, `name`, `polygon_name`) so IDE autocomplete
+  surfaces them past `gobject`. Setter method defaults for `name`
+  (`"raw"`, `"pca"`, `"sNN.pca"`, `"enrichment"`, `"cell"`) moved out of
+  the formals and into an explicit body-side fallback after
+  `read_s4_nesting()`, allowing `name` on the generic without breaking
+  the "user-supplied vs subobject-derived" resolution. `match.call`-based
+  detection replaced with plain `is.null(name)` throughout.
+- `getExpression` adopts `name` as the canonical formal alongside
+  `values` (now a back-compat alias); they error if both supplied and
+  differ.
+- `image_type` formal removed from `getGiottoImage()` and `setGiottoImage()`
+  — already documented as deprecated and unused in body.
 
 # GiottoClass 0.5.1 (2026/05/14)
 

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -279,7 +279,7 @@ polygon_to_raster <- function(polygon, field = NULL) {
 #'     return_giottoPolygon = TRUE
 #' )
 #' gpoints <- getFeatureInfo(g, return_giottoPoints = TRUE)
-#' gimg <- getGiottoImage(g, image_type = "largeImage")
+#' gimg <- getGiottoImage(g, name = list_images(g)$name[1])
 #'
 #' slot(gpoly, "overlaps") <- NULL
 #' overlaps(gpoly) # Should now be NULL
@@ -444,8 +444,7 @@ setMethod(
             image_list <- lapply(image_names, function(i_n) {
                 img <- getGiottoImage(
                     gobject = x,
-                    name = i_n,
-                    image_type = "largeImage"
+                    name = i_n
                 )
                 spatrast <- img@raster_object
                 names(spatrast) <- i_n # ensure name is applied

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -275,7 +275,7 @@ polygon_to_raster <- function(polygon, field = NULL) {
 #' @examples
 #' g <- GiottoData::loadGiottoMini("vizgen")
 #' gpoly <- getPolygonInfo(g,
-#'     polygon_name = "aggregate",
+#'     name = "aggregate",
 #'     return_giottoPolygon = TRUE
 #' )
 #' gpoints <- getFeatureInfo(g, return_giottoPoints = TRUE)
@@ -413,7 +413,7 @@ setMethod(
         #   ---[polys to overlap with]---
         A <- getPolygonInfo(
             gobject = x,
-            polygon_name = spat_info,
+            name = spat_info,
             return_giottoPolygon = TRUE
         )
 
@@ -1011,7 +1011,7 @@ calculateOverlapRaster <- function(
     # * spatial vector
     spatvec <- getPolygonInfo(
         gobject = gobject,
-        polygon_name = spatial_info,
+        name = spatial_info,
         return_giottoPolygon = FALSE
     )
 
@@ -1151,7 +1151,7 @@ calculateOverlapPolygonImages <- function(gobject,
     ## get polygon information
     poly_info <- getPolygonInfo(
         gobject = gobject,
-        polygon_name = spatial_info,
+        name = spatial_info,
         return_giottoPolygon = TRUE
     )
 
@@ -1556,7 +1556,7 @@ calculateOverlapParallel <- function(gobject,
 #' @examples
 #' g <- GiottoData::loadGiottoMini("vizgen")
 #' gpoly <- getPolygonInfo(g,
-#'     polygon_name = "aggregate",
+#'     name = "aggregate",
 #'     return_giottoPolygon = TRUE
 #' )
 #' gpoints <- getFeatureInfo(g, return_giottoPoints = TRUE)
@@ -1624,7 +1624,7 @@ setMethod(
         # get data
         gpoly <- getPolygonInfo(
             gobject = x,
-            polygon_name = spat_info,
+            name = spat_info,
             return_giottoPolygon = TRUE,
             verbose = verbose
         )
@@ -2157,7 +2157,7 @@ overlapImagesToMatrix <- function(gobject,
     ## get polygon information
     polygon_info <- getPolygonInfo(
         gobject = gobject,
-        polygon_name = poly_info,
+        name = poly_info,
         return_giottoPolygon = TRUE
     )
 
@@ -2575,7 +2575,7 @@ aggregateStacksLocations <- function(gobject,
         spat <- spat_units[[spat_i]]
         stackspatvector <- getPolygonInfo(
             gobject = gobject,
-            polygon_name = spat,
+            name = spat,
             polygon_overlap = NULL,
             return_giottoPolygon = FALSE
         )
@@ -2708,7 +2708,7 @@ aggregateStacksPolygonOverlaps <- function(gobject,
     for (i in seq_len(length(spat_units))) {
         spat_unit <- spat_units[i]
         ovlp <- getPolygonInfo(gobject,
-            polygon_name = spat_unit,
+            name = spat_unit,
             polygon_overlap = feat_type
         )
         # vecDT <- gobject@spatial_info[[spat_unit]]@overlaps[[feat_type]]

--- a/R/combine_metadata.R
+++ b/R/combine_metadata.R
@@ -244,7 +244,7 @@ combineCellData <- function(gobject,
         # get spatial poly information
         sv <- getPolygonInfo(
             gobject = gobject,
-            polygon_name = poly_info,
+            name = poly_info,
             return_giottoPolygon = FALSE
         )
 
@@ -491,7 +491,7 @@ combineFeatureOverlapData <- function(gobject,
             for (poly in poly_info) {
                 feat_overlap <- getPolygonInfo(
                     gobject = gobject,
-                    polygon_name = poly,
+                    name = poly,
                     polygon_overlap = feat
                 )
 
@@ -934,7 +934,7 @@ calculateLabelProportions <- function(gobject, labels,
     select_on <- match.arg(select_on, choices = c("spatial_locs", "polygons"))
 
     x <- getPolygonInfo(gobject,
-        polygon_name = spat_info,
+        name = spat_info,
         return_giottoPolygon = TRUE,
         verbose = TRUE
     )
@@ -953,7 +953,7 @@ calculateLabelProportions <- function(gobject, labels,
         },
         "polygons" = {
             y <- getPolygonInfo(gobject,
-                polygon_name = spat_unit,
+                name = spat_unit,
                 return_giottoPolygon = TRUE,
                 verbose = FALSE
             )

--- a/R/giotto_structures.R
+++ b/R/giotto_structures.R
@@ -985,7 +985,7 @@ addSpatialCentroidLocationsLayer <- function(gobject,
     # nesting from
 
     gpoly <- getPolygonInfo(gobject,
-        polygon_name = poly_info,
+        name = poly_info,
         return_giottoPolygon = TRUE
     )
 

--- a/R/images.R
+++ b/R/images.R
@@ -1966,12 +1966,11 @@ reconnect_giottoLargeImage <- function(
 #' @name plotGiottoImage
 #' @description Display a giotto image in the viewer panel. Image object to plot
 #' can be specified by providing the giotto object containing the
-#' image (\code{gobject}), the image object name (\code{image_name}), and the
-#' image object type (\code{image_type}). Alternatively, image objects can be
+#' image (\code{gobject}) and the image object name (\code{image_name}).
+#' Alternatively, image objects can be
 #' directly plotted through their respective associated params.
 #' @param gobject gobject containing giotto image object
 #' @param image_name name of giotto image object
-#' @param image_type type of giotto image object to plot
 #' @param giottoImage giottoImage object to plot directly
 #' @param giottoLargeImage giottoLargeImage object to plot directly
 #' @param largeImage_crop_params_list (optional) named list of params for
@@ -2002,13 +2001,12 @@ reconnect_giottoLargeImage <- function(
 #' g <- GiottoData::loadGiottoMini("vizgen")
 #'
 #' plotGiottoImage(g,
-#'     image_type = "largeImage", image_name = "dapi_z0",
+#'     image_name = "dapi_z0",
 #'     largeImage_max_intensity = 200
 #' )
 #' @export
 plotGiottoImage <- function(gobject = NULL,
     image_name = NULL,
-    image_type = NULL,
     giottoImage = NULL,
     giottoLargeImage = NULL,
     largeImage_crop_params_list = NULL,
@@ -2019,6 +2017,9 @@ plotGiottoImage <- function(gobject = NULL,
         stop("Only one of a giottoImage or a giottoLargeImage can be plotted
             at the same time. \n")
     }
+
+    # image class determines which plotting function is used
+    image_type <- NULL
 
     # Get image object
     if (!is.null(gobject)) {
@@ -2479,8 +2480,7 @@ reconnectGiottoImage <- function(gobject,
             img_list[[image_type]] <- lapply(
                 X = name_list[[image_type]],
                 FUN = getGiottoImage,
-                gobject = gobject,
-                image_type = image_type
+                gobject = gobject
             )
 
             # update file_path
@@ -2556,7 +2556,7 @@ reconnectGiottoImage <- function(gobject,
         for (image_ii in seq_len(length(img_list[[image_type]]))) {
             gobject <- setGiottoImage(
                 gobject = gobject,
-                image = img_list[[image_type]][[image_ii]],
+                x = img_list[[image_type]][[image_ii]],
                 name = name_list[[image_type]][[image_ii]],
                 verbose = FALSE
             )
@@ -2581,8 +2581,6 @@ reconnectGiottoImage <- function(gobject,
 #'   Histogram of intensity values for image objects.
 #' @details Plot is generated from a downsampling of the original image
 #' @param gobject giotto object
-#' @param image_type image object
-#' type (only supports largeImage and is set as default)
 #' @param image_name name of image object to use
 #' @param giottoLargeImage giotto large image object
 #' @param method plot type to show image intensity distribution
@@ -2596,19 +2594,15 @@ reconnectGiottoImage <- function(gobject,
 #' @export
 distGiottoImage <- function(
         gobject = NULL,
-        image_type = "largeImage",
         image_name = NULL,
         giottoLargeImage = NULL,
         method = c("dens", "hist"),
         show_max = TRUE,
         ...) {
     # check params
-    if (image_type != "largeImage") {
-        stop("Only largeImage objects currently supported \n")
-    }
-    if ((is.null(image_type) | is.null(image_name) |
-        is.null(gobject)) & (is.null(giottoLargeImage))) {
-        stop("Image must be given through gobject, image_type, and image_name
+    if ((is.null(image_name) | is.null(gobject)) &
+        (is.null(giottoLargeImage))) {
+        stop("Image must be given through gobject and image_name
             params or as the image object itself \n")
     }
     method <- match.arg(arg = method, choices = c("dens", "hist"))
@@ -2619,10 +2613,8 @@ distGiottoImage <- function(
         show_max = show_max, ...
     )
 
-    # run specific function
-    if (image_type == "largeImage") {
-        do.call(.dist_giottolargeimage, args = a)
-    }
+    # only largeImage is supported
+    do.call(.dist_giottolargeimage, args = a)
 }
 
 

--- a/R/images.R
+++ b/R/images.R
@@ -315,7 +315,7 @@ get_adj_rescale_img <- function(img_minmax,
 #' @returns an updated Giotto object with access to the list of images
 #' @examples
 #' g <- GiottoData::loadGiottoMini("visium")
-#' g_image <- getGiottoImage(g, image_type = "largeImage")
+#' g_image <- getGiottoImage(g, name = list_images(g)$name[1])
 #'
 #' addGiottoImageMG(g, images = list(g_image))
 #' @export
@@ -835,7 +835,6 @@ reconnect_giottoImage_MG <- function(
     if (!is.null(gobject) & !is.null(image_name)) {
         img_obj <- getGiottoImage(
             gobject = gobject,
-            image_type = "largeImage",
             name = image_name
         )
     } else if (!is.null(giottoLargeImage)) {
@@ -932,7 +931,7 @@ reconnect_giottoImage_MG <- function(
 #' @returns \code{largeGiottoImage} object with pointer to stitched image
 #' @examples
 #' g <- GiottoData::loadGiottoMini("visium")
-#' g_image <- getGiottoImage(g, image_type = "largeImage")
+#' g_image <- getGiottoImage(g, name = list_images(g)$name[1])
 #'
 #' stitchGiottoLargeImage(largeImage_list = list(g_image))
 #' @export
@@ -1863,7 +1862,7 @@ updateGiottoLargeImage <- function(gobject = NULL,
 #' @returns an updated Giotto object with access to the list of images
 #' @examples
 #' g <- GiottoData::loadGiottoMini("visium")
-#' g_image <- getGiottoImage(g, image_type = "largeImage")
+#' g_image <- getGiottoImage(g, name = list_images(g)$name[1])
 #'
 #' addGiottoLargeImage(g, largeImages = list(g_image))
 #' @export
@@ -2076,7 +2075,7 @@ plotGiottoImage <- function(gobject = NULL,
 #' @family basic image functions
 #' @examples
 #' g <- GiottoData::loadGiottoMini("visium")
-#' g_image <- getGiottoImage(g, image_type = "largeImage")
+#' g_image <- getGiottoImage(g, name = list_images(g)$name[1])
 #'
 #' addGiottoImage(g, largeImages = list(g_image))
 #' @export

--- a/R/interoperability.R
+++ b/R/interoperability.R
@@ -4312,7 +4312,7 @@ giottoToSpatialData <- function(
     if (!is.null(list_spatial_info(gobject))) {
         dir.create(paste0(temp, "shapes"))
         for (su in spat_unit) {
-            gpoly <- getPolygonInfo(gobject, polygon_name = su)
+            gpoly <- getPolygonInfo(gobject, name = su)
             gpoly_sf <- as.sf(gpoly)
             sf::st_write(gpoly_sf, paste0(temp, "shapes/", su, ".geojson"),
                 delete_dsn = TRUE

--- a/R/interoperability.R
+++ b/R/interoperability.R
@@ -3063,7 +3063,6 @@ giottoToSpatialExperiment <- function(gobject,
             for (i in seq(nrow(giottoImages))) {
                 img <- getGiottoImage(
                     gobject = gobject,
-                    image_type = giottoImages[i]$img_type,
                     name = giottoImages[i]$name
                 )
 

--- a/R/join.R
+++ b/R/join.R
@@ -714,7 +714,7 @@ joinGiottoObjects <- function(gobject_list,
         for (gobj_i in seq_along(updated_object_list)) {
             gpoly <- getPolygonInfo(
                 updated_object_list[[gobj_i]],
-                polygon_name = spat_info,
+                name = spat_info,
                 return_giottoPolygon = TRUE
             )
             spat_information_vector <- gpoly[]

--- a/R/methods-ext.R
+++ b/R/methods-ext.R
@@ -187,7 +187,7 @@ setMethod("ext", signature("giotto"), function(x,
         spat_obj <- switch(type,
             "polygon" = getPolygonInfo(
                 gobject = x,
-                polygon_name = spat_unit,
+                name = spat_unit,
                 return_giottoPolygon = TRUE,
                 verbose = verbose
             ),

--- a/R/methods-relate.R
+++ b/R/methods-relate.R
@@ -99,7 +99,7 @@ setMethod(
         x <- switch(what,
             "polygon" = {
                 getPolygonInfo(x,
-                    polygon_name = spat_unit,
+                    name = spat_unit,
                     return_giottoPolygon = TRUE
                 )
             },

--- a/R/methods-rescale.R
+++ b/R/methods-rescale.R
@@ -409,7 +409,7 @@ rescalePolygons <- function(gobject,
     # 1. get polygon information
     original <- getPolygonInfo(
         gobject = gobject,
-        polygon_name = poly_info,
+        name = poly_info,
         return_giottoPolygon = TRUE
     )
 

--- a/R/methods-setGiotto.R
+++ b/R/methods-setGiotto.R
@@ -156,7 +156,7 @@ setMethod(
     function(gobject, x, ...) {
         gobject <- setGiottoImage(
             gobject = gobject,
-            image = x,
+            x = x,
             name = x@name,
             ...
         )
@@ -171,7 +171,7 @@ setMethod(
     function(gobject, x, ...) {
         gobject <- setGiottoImage(
             gobject = gobject,
-            image = x,
+            x = x,
             name = x@name,
             ...
         )

--- a/R/methods-zoom.R
+++ b/R/methods-zoom.R
@@ -14,7 +14,7 @@ NULL
 #' @returns SpatExtent (invisibly)
 #' @examples
 #' g <- GiottoData::loadGiottoMini("vizgen")
-#' gimg <- getGiottoImage(g, image_type = "largeImage")
+#' gimg <- getGiottoImage(g, name = list_images(g)$name[1])
 #' gpoly <- GiottoData::loadSubObjectMini("giottoPolygon")
 #' gpoints <- GiottoData::loadSubObjectMini("giottoPoints")
 #' e <- ext(6400, 6800, -4860, -4750) # arbitrary

--- a/R/slot_accessors.R
+++ b/R/slot_accessors.R
@@ -277,7 +277,7 @@ set_cell_id <- function(gobject,
 
             cell_IDs <- spatIDs(getPolygonInfo(
                 gobject = gobject,
-                polygon_name = spat_unit,
+                name = spat_unit,
                 return_giottoPolygon = TRUE
             ))
         } else {
@@ -995,7 +995,8 @@ setMethod("getExpression", signature("giotto"), function(
 #' @inheritParams data_access_params
 #' @param x exprObj or list of exprObj to set. Passing NULL will remove a
 #' specified set of expression data from the giotto object
-#' @param name name for the expression information
+#' @param name name for the expression information. NULL (default) takes the
+#' name from \code{x}, falling back to "raw" when \code{x} is unnamed
 #' @param provenance provenance information (optional)
 #' information for the giotto object. Pass NULL to remove an expression object
 #' @param verbose be verbose
@@ -1209,7 +1210,7 @@ setMethod("setExpression", signature("giotto"), function(gobject,
 #' g <- GiottoData::loadGiottoMini("visium")
 #'
 #' set_multiomics(
-#'     gobject = g, result = matrix(rnorm(100), nrow = 10),
+#'     gobject = g, x = matrix(rnorm(100), nrow = 10),
 #'     spat_unit = "cell", feat_type = "rna_protein"
 #' )
 #' @export
@@ -1222,12 +1223,13 @@ set_multiomics <- function(gobject, ...) setMultiomics(gobject, ...)
 #' @param gobject A Giotto object
 #' @param spat_unit spatial unit (e.g. 'cell')
 #' @param feat_type (e.g. 'rna_protein')
-#' @param result A matrix or result from multiomics
+#' @param x A matrix or result from multiomics
 #' integration (e.g. theta weighted values from runWNN)
 #' @param integration_method multiomics integration method used. Default = 'WNN'
 #' @param result_name Default = 'theta_weighted_matrix'
 #' @param verbose be verbose
 #' @param ... additional params to pass
+#' @param result deprecated. Use \code{x}
 #'
 #' @returns A giotto object
 #' @family multiomics accessor functions
@@ -1236,34 +1238,38 @@ set_multiomics <- function(gobject, ...) setMultiomics(gobject, ...)
 #' g <- GiottoData::loadGiottoMini("visium")
 #'
 #' setMultiomics(
-#'     gobject = g, result = matrix(rnorm(100), nrow = 10),
+#'     gobject = g, x = matrix(rnorm(100), nrow = 10),
 #'     spat_unit = "cell", feat_type = "rna_protein"
 #' )
 #' @export
 setGeneric("setMultiomics",
-    function(gobject, result, spat_unit = NULL, feat_type = NULL, ...)
+    function(gobject, x, spat_unit = NULL, feat_type = NULL, ...)
         standardGeneric("setMultiomics"))
 
 #' @rdname setMultiomics
 #' @export
 setMethod("setMultiomics", signature("giotto"), function(gobject,
-    result,
+    x,
     spat_unit = NULL,
     feat_type = NULL,
     integration_method = "WNN",
     result_name = "theta_weighted_matrix",
     verbose = TRUE,
-    ...) {
+    ...,
+    result = deprecated()) {
+    x <- GiottoUtils::deprecate_param(result, x,
+        fun = "setMultiomics", when = "0.5.2"
+    )
     .set_default_nesting(gobject, spat_unit, feat_type)
 
     # If input is null, remove object
-    if (is.null(result)) {
+    if (is.null(x)) {
         if (isTRUE(verbose)) {
-            message("NULL passed to result\n Removing specified result")
+            message("NULL passed to x\n Removing specified result")
         }
         gobject@multiomics[[spat_unit]][[feat_type]][[
             integration_method
-        ]][[result_name]] <- result
+        ]][[result_name]] <- x
         return(gobject)
     }
 
@@ -1282,7 +1288,7 @@ setMethod("setMultiomics", signature("giotto"), function(gobject,
 
     gobject@multiomics[[spat_unit]][[feat_type]][[
         integration_method
-    ]][[result_name]] <- result
+    ]][[result_name]] <- x
     gobject
 })
 
@@ -1302,7 +1308,7 @@ setMethod("setMultiomics", signature("giotto"), function(gobject,
 #' @examples
 #' g <- GiottoData::loadGiottoMini("visium")
 #' g <- setMultiomics(
-#'     gobject = g, result = matrix(rnorm(100), nrow = 10),
+#'     gobject = g, x = matrix(rnorm(100), nrow = 10),
 #'     spat_unit = "cell", feat_type = "rna_protein"
 #' )
 #'
@@ -1326,7 +1332,7 @@ get_multiomics <- function(gobject, ...) getMultiomics(gobject, ...)
 #' @examples
 #' g <- GiottoData::loadGiottoMini("visium")
 #' g <- setMultiomics(
-#'     gobject = g, result = matrix(rnorm(100), nrow = 10),
+#'     gobject = g, x = matrix(rnorm(100), nrow = 10),
 #'     spat_unit = "cell", feat_type = "rna_protein"
 #' )
 #'
@@ -1506,7 +1512,8 @@ setMethod("getSpatialLocations", signature("giotto"), function(gobject,
 #' @inheritParams data_access_params
 #' @param x spatLocsObj or list of spatLocsObj. Passing NULL will remove a
 #' specified set of spatial locations data.
-#' @param name name of spatial locations, default "raw"
+#' @param name name of spatial locations. NULL (default) takes the name from
+#' \code{x}, falling back to "raw" when \code{x} is unnamed
 #' @param provenance provenance information (optional)
 #' @param verbose be verbose
 #' @details Spatial information will be set to the nested location described
@@ -1755,7 +1762,8 @@ setMethod("getDimReduction", signature("giotto"), function(gobject,
 #' @inheritParams data_access_params
 #' @param x dimObj or list of dimObj to set. Passing NULL will remove a
 #' specified set of dimension reduction information from the gobject
-#' @param name name of reduction results
+#' @param name name of reduction results. NULL (default) takes the name from
+#' \code{x}, falling back to "pca" when \code{x} is unnamed
 #' @param reduction reduction on cells or features
 #' @param reduction_method reduction method (e.g. "pca")
 #' @param provenance provenance information (optional)
@@ -2036,8 +2044,8 @@ setMethod("getNearestNetwork", signature("giotto"), function(gobject,
 #' @param x nnNetObj or list of nnNetObj. Passing NULL will remove a specified
 #' set of nearest neighbor network information from the gobject
 #' @param nn_type "kNN" or "sNN"
-#' @param name name of NN network to be used
-#' yet supported.
+#' @param name name of NN network to be used. NULL (default) takes the name
+#' from \code{x}, falling back to "sNN.pca" when \code{x} is unnamed
 #' @param provenance provenance information (optional)
 #' @param verbose be verbose
 #' @returns giotto object
@@ -2647,13 +2655,15 @@ setSpatialGrid <- function(gobject,
 #' @name getPolygonInfo
 #' @description Get giotto polygon spatVector
 #' @param gobject giotto object
-#' @param polygon_name name of polygons. Default is "cell"
+#' @param name name of polygons. NULL (default) selects "cell" when available,
+#' otherwise the first available
 #' @param polygon_overlap include polygon overlap information
 #' @param return_giottoPolygon (Defaults to FALSE) Return as giottoPolygon
 #' S4 object
 #' @param verbose be verbose
 #' @param simplify logical. Whether or not to take object out of a list when
 #' there is a length of 1.
+#' @param polygon_name deprecated. Use \code{name}
 #' @returns spatVector
 #' @family polygon info data accessor functions
 #' @family functions to get data from giotto object
@@ -2663,17 +2673,22 @@ setSpatialGrid <- function(gobject,
 #' getPolygonInfo(g)
 #' @export
 setGeneric("getPolygonInfo",
-    function(gobject, polygon_name = NULL, ...)
+    function(gobject, name = NULL, ...)
         standardGeneric("getPolygonInfo"))
 
 #' @rdname getPolygonInfo
 #' @export
 setMethod("getPolygonInfo", signature("giotto"), function(gobject,
-    polygon_name = NULL,
+    name = NULL,
     polygon_overlap = NULL,
     return_giottoPolygon = FALSE,
     verbose = TRUE,
-    simplify = TRUE) {
+    simplify = TRUE,
+    ...,
+    polygon_name = deprecated()) {
+    name <- GiottoUtils::deprecate_param(polygon_name, name,
+        fun = "getPolygonInfo", when = "0.5.2"
+    )
     slotdata <- slot(gobject, "spatial_info")
     potential_names <- names(slotdata)
 
@@ -2681,22 +2696,22 @@ setMethod("getPolygonInfo", signature("giotto"), function(gobject,
         stop("Giotto object contains no polygon information")
     }
 
-    if (is.null(polygon_name)) {
+    if (is.null(name)) {
         if ("cell" %in% potential_names) {
             # Default to 'cell' if available
-            polygon_name <- "cell"
+            name <- "cell"
         } else {
             # Otherwise the first available
-            polygon_name <- potential_names[1]
+            name <- potential_names[1]
             if (isTRUE(verbose)) {
                 wrap_txtf("No polygon information named 'cell' discovered.
-                Selecting first available ('%s')", polygon_name)
+                Selecting first available ('%s')", name)
             }
         }
     }
 
-    all_p <- identical(polygon_name, ":all:")
-    missing_p <- polygon_name[!polygon_name %in% potential_names]
+    all_p <- identical(name, ":all:")
+    missing_p <- name[!name %in% potential_names]
     if (length(missing_p) > 0L && !all_p) {
         stop(wrap_txtf(
             "No polygon information with name(s): '%s'",
@@ -2705,7 +2720,7 @@ setMethod("getPolygonInfo", signature("giotto"), function(gobject,
         ), call. = FALSE)
     }
 
-    if (!all_p) slotdata <- slotdata[polygon_name]
+    if (!all_p) slotdata <- slotdata[name]
 
     names(slotdata) <- NULL
     out <- lapply(slotdata, function(x) {
@@ -2746,7 +2761,8 @@ setMethod("getPolygonInfo", signature("giotto"), function(gobject,
 #' information (see details)
 #' @param name (optional, character) name to assign to polygon and spatial unit
 #' that polygon might define. Only used for single giottoPolygon objects. Names
-#' are taken from a named list for multiple polygons.
+#' are taken from a named list for multiple polygons. NULL (default) takes the
+#' name from \code{x}, falling back to "cell" when \code{x} is unnamed
 #' @param centroids_to_spatlocs if centroid information is discovered, whether
 #' to additionally set them as a set of spatial locations (default = FALSE)
 #' @param verbose be verbose
@@ -3211,7 +3227,8 @@ setMethod("getSpatialEnrichment", signature("giotto"), function(gobject,
 #' @name setSpatialEnrichment
 #' @description Function to set a spatial enrichment slot
 #' @inheritParams data_access_params
-#' @param name name of spatial enrichment results. Default "DWLS"
+#' @param name name of spatial enrichment results. NULL (default) takes the
+#' name from \code{x}, falling back to "enrichment" when \code{x} is unnamed
 #' @param x spatEnrObj or list of spatEnrObj to set. Passing NULL will remove
 #' a specified set of spatial enrichment information from the gobject.
 #' @param provenance provenance information (optional)
@@ -3446,10 +3463,11 @@ setMethod("getGiottoImage", signature("giotto"), function(gobject,
 #' other modalities of spatial data. \cr For the more general-purpose method
 #' of attaching image objects, see \code{\link{addGiottoImage}}
 #' @param gobject giotto object
-#' @param image giotto image object to be attached without modification to the
+#' @param x giotto image object to be attached without modification to the
 #' giotto object
 #' @param name name of giotto image object
 #' @param verbose be verbose
+#' @param image deprecated. Use \code{x}
 #' @inheritParams data_access_params
 #' @returns giotto object
 #' @family image data accessor functions
@@ -3460,33 +3478,38 @@ setMethod("getGiottoImage", signature("giotto"), function(gobject,
 #' gimg <- getGiottoImage(gobject = g)
 #'
 #' setGiottoImage(g, NULL, name = objName(gimg))
-#' setGiottoImage(gobject = g, image = gimg)
+#' setGiottoImage(gobject = g, x = gimg)
 #' @export
 setGeneric("setGiottoImage",
-    function(gobject, image, name = NULL, ...)
+    function(gobject, x, name = NULL, ...)
         standardGeneric("setGiottoImage"))
 
 #' @rdname setGiottoImage
 #' @export
 setMethod("setGiottoImage", signature("giotto"), function(gobject,
-    image,
+    x,
     name = NULL,
     initialize = FALSE,
-    verbose = NULL) {
-    if (is.null(image)) {
+    verbose = NULL,
+    ...,
+    image = deprecated()) {
+    x <- GiottoUtils::deprecate_param(image, x,
+        fun = "setGiottoImage", when = "0.5.2"
+    )
+    if (is.null(x)) {
         if (!is.null(name)) { # image removal
-            vmsg(.v = verbose, "NULL passed to `image` param
+            vmsg(.v = verbose, "NULL passed to `x` param
                 removing specified image")
-            gobject@images[[name]] <- image
+            gobject@images[[name]] <- x
             return(gobject)
         } else {
-            stop("NULL passed to `image` param, but no specified `name`\n",
+            stop("NULL passed to `x` param, but no specified `name`\n",
                 call. = FALSE
             )
         }
     }
 
-    if (!inherits(image, c("giottoImage", "giottoLargeImage"))) {
+    if (!inherits(x, c("giottoImage", "giottoLargeImage"))) {
         stop(wrap_txt(
             "Unable to set non-giottoImage objects. Please ensure a
             giottoImage or giottoLargeImage is provided to this function.",
@@ -3495,7 +3518,7 @@ setMethod("setGiottoImage", signature("giotto"), function(gobject,
     }
 
     # Default to name stored in object
-    if (is.null(name)) name <- objName(image)
+    if (is.null(name)) name <- objName(x)
 
     # Find existing names
     potential_names <- list_images_names(gobject = gobject)
@@ -3507,7 +3530,7 @@ setMethod("setGiottoImage", signature("giotto"), function(gobject,
         )
     }
 
-    gobject@images[[name]] <- image
+    gobject@images[[name]] <- x
     return(gobject)
 })
 
@@ -3785,7 +3808,7 @@ spatValues <- function(gobject,
         }
         p <- getPolygonInfo(
             gobject = gobject,
-            polygon_name = spat_unit,
+            name = spat_unit,
             return_giottoPolygon = TRUE,
             verbose = FALSE
         )

--- a/R/slot_accessors.R
+++ b/R/slot_accessors.R
@@ -448,7 +448,8 @@ set_feat_id <- function(gobject,
 #' getCellMetadata(g)
 #' @export
 setGeneric("getCellMetadata",
-    function(gobject, ...) standardGeneric("getCellMetadata"))
+    function(gobject, spat_unit = NULL, feat_type = NULL, ...)
+        standardGeneric("getCellMetadata"))
 
 #' @rdname getCellMetadata
 #' @export
@@ -505,7 +506,8 @@ setMethod("getCellMetadata", signature("giotto"), function(gobject,
 #' setCellMetadata(gobject = g, x = createCellMetaObj(m2))
 #' @export
 setGeneric("setCellMetadata",
-    function(gobject, ...) standardGeneric("setCellMetadata"))
+    function(gobject, x, spat_unit = NULL, feat_type = NULL, ...)
+        standardGeneric("setCellMetadata"))
 
 #' @rdname setCellMetadata
 #' @export
@@ -665,7 +667,8 @@ setMethod("setCellMetadata", signature("giotto"), function(gobject,
 #' getFeatureMetadata(g)
 #' @export
 setGeneric("getFeatureMetadata",
-    function(gobject, ...) standardGeneric("getFeatureMetadata"))
+    function(gobject, spat_unit = NULL, feat_type = NULL, ...)
+        standardGeneric("getFeatureMetadata"))
 
 #' @rdname getFeatureMetadata
 #' @export
@@ -720,7 +723,8 @@ setMethod("getFeatureMetadata", signature("giotto"), function(gobject,
 #' setFeatureMetadata(gobject = g, x = createFeatMetaObj(m2))
 #' @export
 setGeneric("setFeatureMetadata",
-    function(gobject, ...) standardGeneric("setFeatureMetadata"))
+    function(gobject, x, spat_unit = NULL, feat_type = NULL, ...)
+        standardGeneric("setFeatureMetadata"))
 
 #' @rdname setFeatureMetadata
 #' @export
@@ -860,8 +864,11 @@ setMethod("setFeatureMetadata", signature("giotto"), function(gobject,
 #' @aliases getExpressionValues
 #' @description Function to get expression values from giotto object
 #' @inheritParams data_access_params
-#' @param values expression values to
-#' extract (e.g. "raw", "normalized", "scaled")
+#' @param name name of expression values to extract (e.g. `"raw"`,
+#' `"normalized"`, `"scaled"`). Canonical form, consistent with the rest
+#' of the slot accessors.
+#' @param values back-compat alias for `name`. If both are supplied they
+#' must agree.
 #' @param output what object type to retrieve the expression as. Currently
 #' either matrix' for the matrix object contained in the exprObj or
 #' 'exprObj' (default) for the exprObj itself are allowed.
@@ -874,31 +881,43 @@ setMethod("setFeatureMetadata", signature("giotto"), function(gobject,
 #' getExpression(g)
 #' @export
 setGeneric("getExpression",
-    function(gobject, ...) standardGeneric("getExpression"))
+    function(gobject, spat_unit = NULL, feat_type = NULL, name = NULL, ...)
+        standardGeneric("getExpression"))
 
 #' @rdname getExpression
 #' @export
 setMethod("getExpression", signature("giotto"), function(
         gobject,
-        values = NULL,
         spat_unit = NULL,
         feat_type = NULL,
+        name = NULL,
+        values = NULL,
         output = c("exprObj", "matrix"),
         set_defaults = TRUE) {
+    # `values` is an alias for `name` (the canonical form, consistent
+    # with the rest of the slot accessors). When both are supplied they
+    # must agree.
+    if (!is.null(values)) {
+        if (!is.null(name) && !identical(name, values)) {
+            stop("getExpression: 'name' and 'values' both supplied but ",
+                "differ. Use one — 'name' is preferred.", call. = FALSE)
+        }
+        name <- values
+    }
     output <- match.arg(output, choices = c("exprObj", "matrix"))
 
     if (isTRUE(set_defaults)) {
         .set_default_nesting(gobject, spat_unit, feat_type)
     }
 
-    potential_values <- list_expression_names(
+    potential_names <- list_expression_names(
         gobject = gobject,
         spat_unit = spat_unit,
         feat_type = feat_type
     )
 
-    if (is.null(values)) values <- potential_values[[1]]
-    if (is.null(values)) {
+    if (is.null(name)) name <- potential_names[[1]]
+    if (is.null(name)) {
         stop(wrap_txt(
             "No expression values discovered by getter:",
             "\nspat_unit:", spat_unit,
@@ -907,27 +926,27 @@ setMethod("getExpression", signature("giotto"), function(
     }
 
     # Targeted error messages for the standard giotto pipeline names
-    if (values == "scaled" & !"scaled" %in% potential_values) {
+    if (name == "scaled" & !"scaled" %in% potential_names) {
         stop(wrap_txt("Scaled expression not found.
                 First run scaling (& normalization) step(s)", errWidth = TRUE))
-    } else if (values == "normalized" & !"normalized" %in% potential_values) {
+    } else if (name == "normalized" & !"normalized" %in% potential_names) {
         stop(wrap_txt("Normalized expression not found.
                 First run normalization step", errWidth = TRUE))
-    } else if (values == "custom" & !"custom" %in% potential_values) {
+    } else if (name == "custom" & !"custom" %in% potential_names) {
         stop(wrap_txt("Custom expression not found.
                 First add custom expression matrix", errWidth = TRUE))
     }
 
-    if (!values %in% potential_values) {
+    if (!name %in% potential_names) {
         stop(wrap_txt("Requested expression info not found [spat_unit:",
             spat_unit, "] [feat_type:",
-            feat_type, "] [values:", values, "]",
+            feat_type, "] [name:", name, "]",
             sep = "",
             errWidth = TRUE
         ))
     }
 
-    expr_vals <- gobject@expression[[spat_unit]][[feat_type]][[values]]
+    expr_vals <- gobject@expression[[spat_unit]][[feat_type]][[name]]
 
     # Reload matrix from h5 file if HDF5-backed (giotto only — giottoMulti
     # has no @h5_file slot)
@@ -992,7 +1011,8 @@ setMethod("getExpression", signature("giotto"), function(
 #' g <- setExpression(gobject = g, x = createExprObj(m, name = "raw"))
 #' @export
 setGeneric("setExpression",
-    function(gobject, ...) standardGeneric("setExpression"))
+    function(gobject, x, spat_unit = NULL, feat_type = NULL, name = NULL, ...)
+        standardGeneric("setExpression"))
 
 #' @rdname setExpression
 #' @export
@@ -1000,7 +1020,7 @@ setMethod("setExpression", signature("giotto"), function(gobject,
     x,
     spat_unit = NULL,
     feat_type = NULL,
-    name = "raw",
+    name = NULL,
     provenance = NULL,
     verbose = TRUE,
     initialize = TRUE,
@@ -1020,7 +1040,7 @@ setMethod("setExpression", signature("giotto"), function(gobject,
     # ones, or vice versa.
     nospec_unit <- is.null(spat_unit)
     nospec_feat <- is.null(feat_type)
-    nospec_name <- is.null(match.call()$name)
+    nospec_name <- is.null(name)
 
     # List input: validate items and iterate. Only forward nesting args that
     # the caller actually supplied; otherwise the recursive call's match.call()
@@ -1081,6 +1101,9 @@ setMethod("setExpression", signature("giotto"), function(gobject,
     # NOTE: read_s4_nesting modifies spat_unit / feat_type / name / provenance
     # in this frame based on the nospec_* flags.
     x <- read_s4_nesting(x)
+    # Fallback for the rare case where neither the caller nor the
+    # subobject supplied a name (objName(x) is NA).
+    if (is.null(name)) name <- "raw"
 
     # Notify on replacement
     potential_names <- list_expression_names(gobject,
@@ -1218,7 +1241,8 @@ set_multiomics <- function(gobject, ...) setMultiomics(gobject, ...)
 #' )
 #' @export
 setGeneric("setMultiomics",
-    function(gobject, ...) standardGeneric("setMultiomics"))
+    function(gobject, result, spat_unit = NULL, feat_type = NULL, ...)
+        standardGeneric("setMultiomics"))
 
 #' @rdname setMultiomics
 #' @export
@@ -1309,7 +1333,8 @@ get_multiomics <- function(gobject, ...) getMultiomics(gobject, ...)
 #' getMultiomics(gobject = g, spat_unit = "cell", feat_type = "rna_protein")
 #' @export
 setGeneric("getMultiomics",
-    function(gobject, ...) standardGeneric("getMultiomics"))
+    function(gobject, spat_unit = NULL, feat_type = NULL, ...)
+        standardGeneric("getMultiomics"))
 
 #' @rdname getMultiomics
 #' @export
@@ -1382,7 +1407,8 @@ setMethod("getMultiomics", signature("giotto"), function(gobject,
 #' getSpatialLocations(g)
 #' @export
 setGeneric("getSpatialLocations",
-    function(gobject, ...) standardGeneric("getSpatialLocations"))
+    function(gobject, spat_unit = NULL, name = NULL, ...)
+        standardGeneric("getSpatialLocations"))
 
 #' @rdname getSpatialLocations
 #' @export
@@ -1497,14 +1523,15 @@ setMethod("getSpatialLocations", signature("giotto"), function(gobject,
 #' setSpatialLocations(gobject = g, x = createSpatLocsObj(sl, name = "raw"))
 #' @export
 setGeneric("setSpatialLocations",
-    function(gobject, ...) standardGeneric("setSpatialLocations"))
+    function(gobject, x, spat_unit = NULL, name = NULL, ...)
+        standardGeneric("setSpatialLocations"))
 
 #' @rdname setSpatialLocations
 #' @export
 setMethod("setSpatialLocations", signature("giotto"), function(gobject,
     x,
     spat_unit = NULL,
-    name = "raw",
+    name = NULL,
     provenance = NULL,
     verbose = TRUE,
     initialize = TRUE,
@@ -1534,11 +1561,11 @@ setMethod("setSpatialLocations", signature("giotto"), function(gobject,
     # whether to overwrite the subobject's nesting values with caller-supplied
     # ones, or vice versa.
     nospec_unit <- is.null(spat_unit)
-    nospec_name <- is.null(match.call()$name)
+    nospec_name <- is.null(name)
 
     # List input: validate items and iterate. Only forward nesting args that
-    # the caller actually supplied; otherwise the recursive call's match.call()
-    # would see name = "raw" (default) and clobber each subobj's own @name.
+    # the caller actually supplied; otherwise the recursive call would
+    # clobber each subobj's own @name with our top-level default.
     if (inherits(x, "list")) {
         if (!all(vapply(x, inherits, "spatLocsObj", FUN.VALUE = logical(1L)))) {
             stop(wrap_txt("Only spatLocsObj or lists of spatLocsObj accepted.
@@ -1584,6 +1611,9 @@ setMethod("setSpatialLocations", signature("giotto"), function(gobject,
     # NOTE: read_s4_nesting modifies spat_unit / name / provenance in this
     # frame based on the nospec_* flags.
     x <- read_s4_nesting(x)
+    # Fallback for the rare case where neither the caller nor the
+    # subobject supplied a name (objName(x) is NA).
+    if (is.null(name)) name <- "raw"
 
     # Notify on replacement
     potential_names <- list_spatial_locations_names(gobject,
@@ -1647,16 +1677,17 @@ setMethod("setSpatialLocations", signature("giotto"), function(gobject,
 #' getDimReduction(g)
 #' @export
 setGeneric("getDimReduction",
-    function(gobject, ...) standardGeneric("getDimReduction"))
+    function(gobject, spat_unit = NULL, feat_type = NULL, name = NULL, ...)
+        standardGeneric("getDimReduction"))
 
 #' @rdname getDimReduction
 #' @export
 setMethod("getDimReduction", signature("giotto"), function(gobject,
     spat_unit = NULL,
     feat_type = NULL,
+    name = NULL,
     reduction = c("cells", "feats"),
     reduction_method = NULL,
-    name = NULL,
     output = c("dimObj", "matrix"),
     set_defaults = TRUE) {
     # back-compat: "data.table" used to be accepted for matrix output
@@ -1740,7 +1771,8 @@ setMethod("getDimReduction", signature("giotto"), function(gobject,
 #' setDimReduction(gobject = g, x = dimred)
 #' @export
 setGeneric("setDimReduction",
-    function(gobject, ...) standardGeneric("setDimReduction"))
+    function(gobject, x, spat_unit = NULL, feat_type = NULL, name = NULL, ...)
+        standardGeneric("setDimReduction"))
 
 #' @rdname setDimReduction
 #' @export
@@ -1748,7 +1780,7 @@ setMethod("setDimReduction", signature("giotto"), function(gobject,
     x,
     spat_unit = NULL,
     feat_type = NULL,
-    name = "pca",
+    name = NULL,
     reduction = c("cells", "feats"),
     reduction_method = c("pca", "umap", "tsne"),
     provenance = NULL,
@@ -1776,7 +1808,7 @@ setMethod("setDimReduction", signature("giotto"), function(gobject,
     # ones, or vice versa. Compute before match.arg() resolves the vectors.
     nospec_unit <- is.null(spat_unit)
     nospec_feat <- is.null(feat_type)
-    nospec_name <- is.null(match.call()$name)
+    nospec_name <- is.null(name)
     nospec_red <- is.null(match.call()$reduction)
     nospec_red_method <- is.null(match.call()$reduction_method)
 
@@ -1850,6 +1882,9 @@ setMethod("setDimReduction", signature("giotto"), function(gobject,
     # reduction / reduction_method / provenance in this frame based on
     # nospec_* flags.
     x <- read_s4_nesting(x)
+    # Fallback for the rare case where neither the caller nor the
+    # subobject supplied a name (objName(x) is NA).
+    if (is.null(name)) name <- "pca"
 
     # Notify on replacement
     potential_names <- list_dim_reductions_names(gobject,
@@ -1911,15 +1946,16 @@ setMethod("setDimReduction", signature("giotto"), function(gobject,
 #' getNearestNetwork(gobject = g)
 #' @export
 setGeneric("getNearestNetwork",
-    function(gobject, ...) standardGeneric("getNearestNetwork"))
+    function(gobject, spat_unit = NULL, feat_type = NULL, name = NULL, ...)
+        standardGeneric("getNearestNetwork"))
 
 #' @rdname getNearestNetwork
 #' @export
 setMethod("getNearestNetwork", signature("giotto"), function(gobject,
     spat_unit = NULL,
     feat_type = NULL,
-    nn_type = NULL,
     name = NULL,
+    nn_type = NULL,
     output = c("nnNetObj", "igraph", "data.table"),
     set_defaults = TRUE) {
     output <- match.arg(
@@ -2014,7 +2050,8 @@ setMethod("getNearestNetwork", signature("giotto"), function(gobject,
 #' setNearestNetwork(gobject = g, x = dimred)
 #' @export
 setGeneric("setNearestNetwork",
-    function(gobject, ...) standardGeneric("setNearestNetwork"))
+    function(gobject, x, spat_unit = NULL, feat_type = NULL, name = NULL, ...)
+        standardGeneric("setNearestNetwork"))
 
 #' @rdname setNearestNetwork
 #' @export
@@ -2022,8 +2059,8 @@ setMethod("setNearestNetwork", signature("giotto"), function(gobject,
     x,
     spat_unit = NULL,
     feat_type = NULL,
+    name = NULL,
     nn_type = "sNN",
-    name = "sNN.pca",
     provenance = NULL,
     verbose = TRUE,
     initialize = TRUE,
@@ -2052,7 +2089,7 @@ setMethod("setNearestNetwork", signature("giotto"), function(gobject,
     nospec_unit <- is.null(spat_unit)
     nospec_feat <- is.null(feat_type)
     nospec_net <- is.null(match.call()$nn_type)
-    nospec_name <- is.null(match.call()$name)
+    nospec_name <- is.null(name)
 
     # List input: validate items and iterate. Only forward nesting args that
     # the caller supplied; otherwise the recursive call's match.call() would
@@ -2108,6 +2145,9 @@ setMethod("setNearestNetwork", signature("giotto"), function(gobject,
     # NOTE: read_s4_nesting modifies spat_unit / feat_type / name / nn_type /
     # provenance in this frame based on nospec_* flags.
     x <- read_s4_nesting(x)
+    # Fallback for the rare case where neither the caller nor the
+    # subobject supplied a name (objName(x) is NA).
+    if (is.null(name)) name <- "sNN.pca"
 
     # Notify on replacement
     potential_names <- list_nearest_networks_names(gobject,
@@ -2173,7 +2213,8 @@ setMethod("setNearestNetwork", signature("giotto"), function(gobject,
 #' getSpatialNetwork(g)
 #' @export
 setGeneric("getSpatialNetwork",
-    function(gobject, ...) standardGeneric("getSpatialNetwork"))
+    function(gobject, spat_unit = NULL, name = NULL, ...)
+        standardGeneric("getSpatialNetwork"))
 
 #' @rdname getSpatialNetwork
 #' @export
@@ -2300,7 +2341,8 @@ setMethod("getSpatialNetwork", signature("giotto"), function(gobject,
 #' setSpatialNetwork(gobject = g, x = spatnet)
 #' @export
 setGeneric("setSpatialNetwork",
-    function(gobject, ...) standardGeneric("setSpatialNetwork"))
+    function(gobject, x, spat_unit = NULL, name = NULL, ...)
+        standardGeneric("setSpatialNetwork"))
 
 #' @rdname setSpatialNetwork
 #' @export
@@ -2336,7 +2378,7 @@ setMethod("setSpatialNetwork", signature("giotto"), function(gobject,
     # whether to overwrite the subobject's nesting values with caller-supplied
     # ones, or vice versa.
     nospec_unit <- is.null(spat_unit)
-    nospec_name <- is.null(match.call()$name)
+    nospec_name <- is.null(name)
 
     # List input: validate items and iterate via self-recursion.
     if (inherits(x, "list")) {
@@ -2621,7 +2663,8 @@ setSpatialGrid <- function(gobject,
 #' getPolygonInfo(g)
 #' @export
 setGeneric("getPolygonInfo",
-    function(gobject, ...) standardGeneric("getPolygonInfo"))
+    function(gobject, polygon_name = NULL, ...)
+        standardGeneric("getPolygonInfo"))
 
 #' @rdname getPolygonInfo
 #' @export
@@ -2724,13 +2767,14 @@ setMethod("getPolygonInfo", signature("giotto"), function(gobject,
 #' setPolygonInfo(gobject = g, x = polyinfo)
 #' @export
 setGeneric("setPolygonInfo",
-    function(gobject, ...) standardGeneric("setPolygonInfo"))
+    function(gobject, x, name = NULL, ...)
+        standardGeneric("setPolygonInfo"))
 
 #' @rdname setPolygonInfo
 #' @export
 setMethod("setPolygonInfo", signature("giotto"), function(gobject,
     x,
-    name = "cell",
+    name = NULL,
     centroids_to_spatlocs = FALSE,
     verbose = TRUE,
     initialize = TRUE,
@@ -2752,7 +2796,7 @@ setMethod("setPolygonInfo", signature("giotto"), function(gobject,
 
     # `nospec_name` is read by read_s4_nesting() to decide whether to override
     # the subobject's @name with the caller-supplied `name`.
-    nospec_name <- !methods::hasArg(name)
+    nospec_name <- is.null(name)
 
     # List input: validate items and iterate. Only forward `name` if the user
     # supplied it, so each subobj's own @name is honored by read_s4_nesting().
@@ -2799,6 +2843,9 @@ setMethod("setPolygonInfo", signature("giotto"), function(gobject,
     # NOTE: read_s4_nesting modifies `name` in this frame based on
     # nospec_name (subobj's @name wins when caller didn't supply one).
     x <- read_s4_nesting(x)
+    # Fallback for the rare case where neither the caller nor the
+    # subobject supplied a name (objName(x) is NA).
+    if (is.null(name)) name <- "cell"
 
     # Notify on replacement
     if (name %in% names(gobject@spatial_info)) {
@@ -2879,7 +2926,8 @@ setMethod("setPolygonInfo", signature("giotto"), function(gobject,
 #' getFeatureInfo(g)
 #' @export
 setGeneric("getFeatureInfo",
-    function(gobject, ...) standardGeneric("getFeatureInfo"))
+    function(gobject, feat_type = NULL, ...)
+        standardGeneric("getFeatureInfo"))
 
 #' @rdname getFeatureInfo
 #' @export
@@ -2954,7 +3002,8 @@ setMethod("getFeatureInfo", signature("giotto"), function(gobject,
 #' setFeatureInfo(gobject = g, x = featinfo)
 #' @export
 setGeneric("setFeatureInfo",
-    function(gobject, ...) standardGeneric("setFeatureInfo"))
+    function(gobject, x, feat_type = NULL, ...)
+        standardGeneric("setFeatureInfo"))
 
 #' @rdname setFeatureInfo
 #' @export
@@ -3093,7 +3142,8 @@ setMethod("setFeatureInfo", signature("giotto"), function(gobject,
 #' getSpatialEnrichment(g, spat_unit = "aggregate", name = "cluster_metagene")
 #' @export
 setGeneric("getSpatialEnrichment",
-    function(gobject, ...) standardGeneric("getSpatialEnrichment"))
+    function(gobject, spat_unit = NULL, feat_type = NULL, name = NULL, ...)
+        standardGeneric("getSpatialEnrichment"))
 
 #' @rdname getSpatialEnrichment
 #' @export
@@ -3176,7 +3226,8 @@ setMethod("getSpatialEnrichment", signature("giotto"), function(gobject,
 #' g <- setSpatialEnrichment(g, spatenrich)
 #' @export
 setGeneric("setSpatialEnrichment",
-    function(gobject, ...) standardGeneric("setSpatialEnrichment"))
+    function(gobject, x, spat_unit = NULL, feat_type = NULL, name = NULL, ...)
+        standardGeneric("setSpatialEnrichment"))
 
 #' @rdname setSpatialEnrichment
 #' @export
@@ -3184,7 +3235,7 @@ setMethod("setSpatialEnrichment", signature("giotto"), function(gobject,
     x,
     spat_unit = NULL,
     feat_type = NULL,
-    name = "enrichment",
+    name = NULL,
     provenance = NULL,
     verbose = TRUE,
     initialize = TRUE,
@@ -3219,7 +3270,7 @@ setMethod("setSpatialEnrichment", signature("giotto"), function(gobject,
     # ones, or vice versa.
     nospec_unit <- is.null(spat_unit)
     nospec_feat <- is.null(feat_type)
-    nospec_name <- is.null(match.call()$name)
+    nospec_name <- is.null(name)
 
     # List input: validate items and iterate via self-recursion. Only forward
     # nesting args that the caller supplied.
@@ -3272,6 +3323,9 @@ setMethod("setSpatialEnrichment", signature("giotto"), function(gobject,
     # NOTE: read_s4_nesting modifies spat_unit / feat_type / name /
     # provenance in this frame based on nospec_* flags.
     x <- read_s4_nesting(x)
+    # Fallback for the rare case where neither the caller nor the
+    # subobject supplied a name (objName(x) is NA).
+    if (is.null(name)) name <- "enrichment"
 
     # Notify on replacement
     if (isTRUE(verbose)) {
@@ -3325,7 +3379,6 @@ setMethod("setSpatialEnrichment", signature("giotto"), function(gobject,
 #' @name getGiottoImage
 #' @description Get giotto one or more image objects from gobject
 #' @param gobject giotto object
-#' @param image_type deprecated
 #' @param name character vector. Names giotto image object(s)
 #' \code{\link{showGiottoImageNames}} to get
 #' @returns a giotto image object
@@ -3337,12 +3390,12 @@ setMethod("setSpatialEnrichment", signature("giotto"), function(gobject,
 #' getGiottoImage(gobject = g)
 #' @export
 setGeneric("getGiottoImage",
-    function(gobject, ...) standardGeneric("getGiottoImage"))
+    function(gobject, name = NULL, ...)
+        standardGeneric("getGiottoImage"))
 
 #' @rdname getGiottoImage
 #' @export
 setMethod("getGiottoImage", signature("giotto"), function(gobject,
-    image_type = NULL,
     name = NULL) {
     if (identical(name, ":all:")) {
         all_imgs <- gobject@images
@@ -3395,7 +3448,6 @@ setMethod("getGiottoImage", signature("giotto"), function(gobject,
 #' @param gobject giotto object
 #' @param image giotto image object to be attached without modification to the
 #' giotto object
-#' @param image_type deprecated
 #' @param name name of giotto image object
 #' @param verbose be verbose
 #' @inheritParams data_access_params
@@ -3411,13 +3463,13 @@ setMethod("getGiottoImage", signature("giotto"), function(gobject,
 #' setGiottoImage(gobject = g, image = gimg)
 #' @export
 setGeneric("setGiottoImage",
-    function(gobject, ...) standardGeneric("setGiottoImage"))
+    function(gobject, image, name = NULL, ...)
+        standardGeneric("setGiottoImage"))
 
 #' @rdname setGiottoImage
 #' @export
 setMethod("setGiottoImage", signature("giotto"), function(gobject,
     image,
-    image_type = NULL,
     name = NULL,
     initialize = FALSE,
     verbose = NULL) {

--- a/R/slot_check.R
+++ b/R/slot_check.R
@@ -800,7 +800,7 @@
             # get spat_info
             sinfo <- getPolygonInfo(
                 gobject = gobject,
-                polygon_name = su_i,
+                name = su_i,
                 return_giottoPolygon = TRUE
             )
 

--- a/R/spatial_query.R
+++ b/R/spatial_query.R
@@ -413,7 +413,7 @@ spatQueryGiottoPolygons <- spatQuery
         } else if (spat_unit %in% avail_poly) { # centroids from SpatVector
             sv <- getPolygonInfo(
                 gobject = gobject,
-                polygon_name = spat_unit,
+                name = spat_unit,
                 return_giottoPolygon = FALSE
             )
             sv <- centroids(sv)
@@ -422,7 +422,7 @@ spatQueryGiottoPolygons <- spatQuery
     } else if (spat_unit %in% avail_poly) {
         sv <- getPolygonInfo(
             gobject = gobject,
-            polygon_name = spat_unit,
+            name = spat_unit,
             return_giottoPolygon = FALSE
         )
     }

--- a/man/addGiottoImage.Rd
+++ b/man/addGiottoImage.Rd
@@ -38,7 +38,7 @@ Adds lists of giottoImages and giottoLargeImages to gobjects
 }
 \examples{
 g <- GiottoData::loadGiottoMini("visium")
-g_image <- getGiottoImage(g, image_type = "largeImage")
+g_image <- getGiottoImage(g, name = list_images(g)$name[1])
 
 addGiottoImage(g, largeImages = list(g_image))
 }

--- a/man/addGiottoImageMG.Rd
+++ b/man/addGiottoImageMG.Rd
@@ -39,7 +39,7 @@ Adds giotto image objects to your giotto object
 }
 \examples{
 g <- GiottoData::loadGiottoMini("visium")
-g_image <- getGiottoImage(g, image_type = "largeImage")
+g_image <- getGiottoImage(g, name = list_images(g)$name[1])
 
 addGiottoImageMG(g, images = list(g_image))
 }

--- a/man/addGiottoLargeImage.Rd
+++ b/man/addGiottoLargeImage.Rd
@@ -38,7 +38,7 @@ Add giotto image objects to \code{giotto} object
 }
 \examples{
 g <- GiottoData::loadGiottoMini("visium")
-g_image <- getGiottoImage(g, image_type = "largeImage")
+g_image <- getGiottoImage(g, name = list_images(g)$name[1])
 
 addGiottoLargeImage(g, largeImages = list(g_image))
 }

--- a/man/calculateOverlap.Rd
+++ b/man/calculateOverlap.Rd
@@ -168,7 +168,7 @@ points info.
 \examples{
 g <- GiottoData::loadGiottoMini("vizgen")
 gpoly <- getPolygonInfo(g,
-    polygon_name = "aggregate",
+    name = "aggregate",
     return_giottoPolygon = TRUE
 )
 gpoints <- getFeatureInfo(g, return_giottoPoints = TRUE)

--- a/man/calculateOverlap.Rd
+++ b/man/calculateOverlap.Rd
@@ -172,7 +172,7 @@ gpoly <- getPolygonInfo(g,
     return_giottoPolygon = TRUE
 )
 gpoints <- getFeatureInfo(g, return_giottoPoints = TRUE)
-gimg <- getGiottoImage(g, image_type = "largeImage")
+gimg <- getGiottoImage(g, name = list_images(g)$name[1])
 
 slot(gpoly, "overlaps") <- NULL
 overlaps(gpoly) # Should now be NULL

--- a/man/distGiottoImage.Rd
+++ b/man/distGiottoImage.Rd
@@ -6,7 +6,6 @@
 \usage{
 distGiottoImage(
   gobject = NULL,
-  image_type = "largeImage",
   image_name = NULL,
   giottoLargeImage = NULL,
   method = c("dens", "hist"),
@@ -16,9 +15,6 @@ distGiottoImage(
 }
 \arguments{
 \item{gobject}{giotto object}
-
-\item{image_type}{image object
-type (only supports largeImage and is set as default)}
 
 \item{image_name}{name of image object to use}
 

--- a/man/getCellMetadata.Rd
+++ b/man/getCellMetadata.Rd
@@ -5,7 +5,7 @@
 \alias{getCellMetadata,giotto-method}
 \title{getCellMetadata}
 \usage{
-getCellMetadata(gobject, ...)
+getCellMetadata(gobject, spat_unit = NULL, feat_type = NULL, ...)
 
 \S4method{getCellMetadata}{giotto}(
   gobject,
@@ -19,11 +19,11 @@ getCellMetadata(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
+
+\item{...}{additional params to pass}
 
 \item{output}{return as either 'data.table' or 'cellMetaObj'}
 

--- a/man/getDimReduction.Rd
+++ b/man/getDimReduction.Rd
@@ -5,15 +5,15 @@
 \alias{getDimReduction,giotto-method}
 \title{Get dimension reduction}
 \usage{
-getDimReduction(gobject, ...)
+getDimReduction(gobject, spat_unit = NULL, feat_type = NULL, name = NULL, ...)
 
 \S4method{getDimReduction}{giotto}(
   gobject,
   spat_unit = NULL,
   feat_type = NULL,
+  name = NULL,
   reduction = c("cells", "feats"),
   reduction_method = NULL,
-  name = NULL,
   output = c("dimObj", "matrix"),
   set_defaults = TRUE
 )
@@ -21,17 +21,17 @@ getDimReduction(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
+\item{name}{name of reduction results}
+
+\item{...}{additional params to pass}
+
 \item{reduction}{reduction on cells or features (e.g. "cells", "feats")}
 
 \item{reduction_method}{reduction method (e.g. "pca", "umap", "tsne")}
-
-\item{name}{name of reduction results}
 
 \item{output}{object type to return as. Either 'dimObj' (default) or 'matrix'
 of the embedding coordinates.}

--- a/man/getExpression.Rd
+++ b/man/getExpression.Rd
@@ -6,13 +6,14 @@
 \alias{getExpression,giotto-method}
 \title{Get expression values}
 \usage{
-getExpression(gobject, ...)
+getExpression(gobject, spat_unit = NULL, feat_type = NULL, name = NULL, ...)
 
 \S4method{getExpression}{giotto}(
   gobject,
-  values = NULL,
   spat_unit = NULL,
   feat_type = NULL,
+  name = NULL,
+  values = NULL,
   output = c("exprObj", "matrix"),
   set_defaults = TRUE
 )
@@ -20,14 +21,18 @@ getExpression(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
-\item{values}{expression values to
-extract (e.g. "raw", "normalized", "scaled")}
-
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
+
+\item{name}{name of expression values to extract (e.g. \code{"raw"},
+\code{"normalized"}, \code{"scaled"}). Canonical form, consistent with the rest
+of the slot accessors.}
+
+\item{...}{additional params to pass}
+
+\item{values}{back-compat alias for \code{name}. If both are supplied they
+must agree.}
 
 \item{output}{what object type to retrieve the expression as. Currently
 either matrix' for the matrix object contained in the exprObj or

--- a/man/getFeatureInfo.Rd
+++ b/man/getFeatureInfo.Rd
@@ -5,7 +5,7 @@
 \alias{getFeatureInfo,giotto-method}
 \title{Get feature info}
 \usage{
-getFeatureInfo(gobject, ...)
+getFeatureInfo(gobject, feat_type = NULL, ...)
 
 \S4method{getFeatureInfo}{giotto}(
   gobject,
@@ -18,9 +18,9 @@ getFeatureInfo(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
+
+\item{...}{additional params to pass}
 
 \item{return_giottoPoints}{return as a giottoPoints object}
 

--- a/man/getFeatureMetadata.Rd
+++ b/man/getFeatureMetadata.Rd
@@ -5,7 +5,7 @@
 \alias{getFeatureMetadata,giotto-method}
 \title{getFeatureMetadata}
 \usage{
-getFeatureMetadata(gobject, ...)
+getFeatureMetadata(gobject, spat_unit = NULL, feat_type = NULL, ...)
 
 \S4method{getFeatureMetadata}{giotto}(
   gobject,
@@ -19,11 +19,11 @@ getFeatureMetadata(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
+
+\item{...}{additional params to pass}
 
 \item{output}{return as either 'data.table' or 'featMetaObj'}
 

--- a/man/getGiottoImage.Rd
+++ b/man/getGiottoImage.Rd
@@ -5,14 +5,12 @@
 \alias{getGiottoImage,giotto-method}
 \title{Get giotto image object}
 \usage{
-getGiottoImage(gobject, ...)
+getGiottoImage(gobject, name = NULL, ...)
 
-\S4method{getGiottoImage}{giotto}(gobject, image_type = NULL, name = NULL)
+\S4method{getGiottoImage}{giotto}(gobject, name = NULL)
 }
 \arguments{
 \item{gobject}{giotto object}
-
-\item{image_type}{deprecated}
 
 \item{name}{character vector. Names giotto image object(s)
 \code{\link{showGiottoImageNames}} to get}

--- a/man/getMultiomics.Rd
+++ b/man/getMultiomics.Rd
@@ -5,7 +5,7 @@
 \alias{getMultiomics,giotto-method}
 \title{Get multiomics integration results}
 \usage{
-getMultiomics(gobject, ...)
+getMultiomics(gobject, spat_unit = NULL, feat_type = NULL, ...)
 
 \S4method{getMultiomics}{giotto}(
   gobject,

--- a/man/getMultiomics.Rd
+++ b/man/getMultiomics.Rd
@@ -35,7 +35,7 @@ Get a multiomics integration result from a Giotto object
 \examples{
 g <- GiottoData::loadGiottoMini("visium")
 g <- setMultiomics(
-    gobject = g, result = matrix(rnorm(100), nrow = 10),
+    gobject = g, x = matrix(rnorm(100), nrow = 10),
     spat_unit = "cell", feat_type = "rna_protein"
 )
 

--- a/man/getNearestNetwork.Rd
+++ b/man/getNearestNetwork.Rd
@@ -5,14 +5,20 @@
 \alias{getNearestNetwork,giotto-method}
 \title{Get nearest neighbor network}
 \usage{
-getNearestNetwork(gobject, ...)
+getNearestNetwork(
+  gobject,
+  spat_unit = NULL,
+  feat_type = NULL,
+  name = NULL,
+  ...
+)
 
 \S4method{getNearestNetwork}{giotto}(
   gobject,
   spat_unit = NULL,
   feat_type = NULL,
-  nn_type = NULL,
   name = NULL,
+  nn_type = NULL,
   output = c("nnNetObj", "igraph", "data.table"),
   set_defaults = TRUE
 )
@@ -20,15 +26,15 @@ getNearestNetwork(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
-\item{nn_type}{"kNN" or "sNN"}
-
 \item{name}{name of NN network to be used}
+
+\item{...}{additional params to pass}
+
+\item{nn_type}{"kNN" or "sNN"}
 
 \item{output}{return a giotto \code{nnNetObj}, \code{igraph}, \code{data.table} object.
 Default 'nnNetObj'}

--- a/man/getPolygonInfo.Rd
+++ b/man/getPolygonInfo.Rd
@@ -5,7 +5,7 @@
 \alias{getPolygonInfo,giotto-method}
 \title{Get polygon info}
 \usage{
-getPolygonInfo(gobject, ...)
+getPolygonInfo(gobject, polygon_name = NULL, ...)
 
 \S4method{getPolygonInfo}{giotto}(
   gobject,

--- a/man/getPolygonInfo.Rd
+++ b/man/getPolygonInfo.Rd
@@ -5,21 +5,24 @@
 \alias{getPolygonInfo,giotto-method}
 \title{Get polygon info}
 \usage{
-getPolygonInfo(gobject, polygon_name = NULL, ...)
+getPolygonInfo(gobject, name = NULL, ...)
 
 \S4method{getPolygonInfo}{giotto}(
   gobject,
-  polygon_name = NULL,
+  name = NULL,
   polygon_overlap = NULL,
   return_giottoPolygon = FALSE,
   verbose = TRUE,
-  simplify = TRUE
+  simplify = TRUE,
+  ...,
+  polygon_name = deprecated()
 )
 }
 \arguments{
 \item{gobject}{giotto object}
 
-\item{polygon_name}{name of polygons. Default is "cell"}
+\item{name}{name of polygons. NULL (default) selects "cell" when available,
+otherwise the first available}
 
 \item{polygon_overlap}{include polygon overlap information}
 
@@ -30,6 +33,8 @@ S4 object}
 
 \item{simplify}{logical. Whether or not to take object out of a list when
 there is a length of 1.}
+
+\item{polygon_name}{deprecated. Use \code{name}}
 }
 \value{
 spatVector

--- a/man/getSpatialEnrichment.Rd
+++ b/man/getSpatialEnrichment.Rd
@@ -5,7 +5,13 @@
 \alias{getSpatialEnrichment,giotto-method}
 \title{Get spatial enrichment}
 \usage{
-getSpatialEnrichment(gobject, ...)
+getSpatialEnrichment(
+  gobject,
+  spat_unit = NULL,
+  feat_type = NULL,
+  name = NULL,
+  ...
+)
 
 \S4method{getSpatialEnrichment}{giotto}(
   gobject,
@@ -20,13 +26,13 @@ getSpatialEnrichment(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
 \item{name}{name of spatial enrichment results. Default "DWLS"}
+
+\item{...}{additional params to pass}
 
 \item{output}{what format in which to get information (e.g. "data.table")}
 

--- a/man/getSpatialLocations.Rd
+++ b/man/getSpatialLocations.Rd
@@ -5,7 +5,7 @@
 \alias{getSpatialLocations,giotto-method}
 \title{Get spatial locations}
 \usage{
-getSpatialLocations(gobject, ...)
+getSpatialLocations(gobject, spat_unit = NULL, name = NULL, ...)
 
 \S4method{getSpatialLocations}{giotto}(
   gobject,
@@ -21,12 +21,12 @@ getSpatialLocations(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{name}{name of spatial
 locations (defaults to first name in spatial_locs slot, e.g. "raw")}
+
+\item{...}{additional params to pass}
 
 \item{output}{what object type to get the spatial locations as. Default is as
 a 'spatLocsObj'. Returning as 'data.table' is also possible.}

--- a/man/getSpatialNetwork.Rd
+++ b/man/getSpatialNetwork.Rd
@@ -5,7 +5,7 @@
 \alias{getSpatialNetwork,giotto-method}
 \title{Get spatial network}
 \usage{
-getSpatialNetwork(gobject, ...)
+getSpatialNetwork(gobject, spat_unit = NULL, name = NULL, ...)
 
 \S4method{getSpatialNetwork}{giotto}(
   gobject,
@@ -21,11 +21,11 @@ getSpatialNetwork(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{name}{name of spatial network}
+
+\item{...}{additional params to pass}
 
 \item{output}{object type to return as. Options:
 'spatialNetworkObj' (default),

--- a/man/get_multiomics.Rd
+++ b/man/get_multiomics.Rd
@@ -26,7 +26,7 @@ Get a multiomics integration result from a Giotto object
 \examples{
 g <- GiottoData::loadGiottoMini("visium")
 g <- setMultiomics(
-    gobject = g, result = matrix(rnorm(100), nrow = 10),
+    gobject = g, x = matrix(rnorm(100), nrow = 10),
     spat_unit = "cell", feat_type = "rna_protein"
 )
 

--- a/man/overlapToMatrix.Rd
+++ b/man/overlapToMatrix.Rd
@@ -121,7 +121,7 @@ create a count matrix based on overlap results from
 \examples{
 g <- GiottoData::loadGiottoMini("vizgen")
 gpoly <- getPolygonInfo(g,
-    polygon_name = "aggregate",
+    name = "aggregate",
     return_giottoPolygon = TRUE
 )
 gpoints <- getFeatureInfo(g, return_giottoPoints = TRUE)

--- a/man/plotGiottoImage.Rd
+++ b/man/plotGiottoImage.Rd
@@ -7,7 +7,6 @@
 plotGiottoImage(
   gobject = NULL,
   image_name = NULL,
-  image_type = NULL,
   giottoImage = NULL,
   giottoLargeImage = NULL,
   largeImage_crop_params_list = NULL,
@@ -19,8 +18,6 @@ plotGiottoImage(
 \item{gobject}{gobject containing giotto image object}
 
 \item{image_name}{name of giotto image object}
-
-\item{image_type}{type of giotto image object to plot}
 
 \item{giottoImage}{giottoImage object to plot directly}
 
@@ -41,8 +38,8 @@ image
 \description{
 Display a giotto image in the viewer panel. Image object to plot
 can be specified by providing the giotto object containing the
-image (\code{gobject}), the image object name (\code{image_name}), and the
-image object type (\code{image_type}). Alternatively, image objects can be
+image (\code{gobject}) and the image object name (\code{image_name}).
+Alternatively, image objects can be
 directly plotted through their respective associated params.
 }
 \section{largeImage-specific additional params}{
@@ -68,7 +65,7 @@ color scaling is desired.
 g <- GiottoData::loadGiottoMini("vizgen")
 
 plotGiottoImage(g,
-    image_type = "largeImage", image_name = "dapi_z0",
+    image_name = "dapi_z0",
     largeImage_max_intensity = 200
 )
 }

--- a/man/setCellMetadata.Rd
+++ b/man/setCellMetadata.Rd
@@ -5,7 +5,7 @@
 \alias{setCellMetadata,giotto-method}
 \title{Set cell metadata}
 \usage{
-setCellMetadata(gobject, ...)
+setCellMetadata(gobject, x, spat_unit = NULL, feat_type = NULL, ...)
 
 \S4method{setCellMetadata}{giotto}(
   gobject,
@@ -21,14 +21,14 @@ setCellMetadata(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{x}{cellMetaObj or list of cellMetaObj to set. Passing NULL will
 reset a specified set of cell metadata in the giotto object.}
 
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
+
+\item{...}{additional params to pass}
 
 \item{provenance}{provenance information (optional)}
 

--- a/man/setDimReduction.Rd
+++ b/man/setDimReduction.Rd
@@ -38,7 +38,8 @@ specified set of dimension reduction information from the gobject}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
-\item{name}{name of reduction results}
+\item{name}{name of reduction results. NULL (default) takes the name from
+\code{x}, falling back to "pca" when \code{x} is unnamed}
 
 \item{...}{additional params to pass}
 

--- a/man/setDimReduction.Rd
+++ b/man/setDimReduction.Rd
@@ -5,14 +5,21 @@
 \alias{setDimReduction,giotto-method}
 \title{Set dimension reduction data}
 \usage{
-setDimReduction(gobject, ...)
+setDimReduction(
+  gobject,
+  x,
+  spat_unit = NULL,
+  feat_type = NULL,
+  name = NULL,
+  ...
+)
 
 \S4method{setDimReduction}{giotto}(
   gobject,
   x,
   spat_unit = NULL,
   feat_type = NULL,
-  name = "pca",
+  name = NULL,
   reduction = c("cells", "feats"),
   reduction_method = c("pca", "umap", "tsne"),
   provenance = NULL,
@@ -24,8 +31,6 @@ setDimReduction(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{x}{dimObj or list of dimObj to set. Passing NULL will remove a
 specified set of dimension reduction information from the gobject}
 
@@ -34,6 +39,8 @@ specified set of dimension reduction information from the gobject}
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
 \item{name}{name of reduction results}
+
+\item{...}{additional params to pass}
 
 \item{reduction}{reduction on cells or features}
 

--- a/man/setExpression.Rd
+++ b/man/setExpression.Rd
@@ -30,7 +30,8 @@ specified set of expression data from the giotto object}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
-\item{name}{name for the expression information}
+\item{name}{name for the expression information. NULL (default) takes the
+name from \code{x}, falling back to "raw" when \code{x} is unnamed}
 
 \item{...}{additional params to pass}
 

--- a/man/setExpression.Rd
+++ b/man/setExpression.Rd
@@ -6,14 +6,14 @@
 \alias{setExpression,giotto-method}
 \title{Set expression data}
 \usage{
-setExpression(gobject, ...)
+setExpression(gobject, x, spat_unit = NULL, feat_type = NULL, name = NULL, ...)
 
 \S4method{setExpression}{giotto}(
   gobject,
   x,
   spat_unit = NULL,
   feat_type = NULL,
-  name = "raw",
+  name = NULL,
   provenance = NULL,
   verbose = TRUE,
   initialize = TRUE,
@@ -23,8 +23,6 @@ setExpression(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{x}{exprObj or list of exprObj to set. Passing NULL will remove a
 specified set of expression data from the giotto object}
 
@@ -33,6 +31,8 @@ specified set of expression data from the giotto object}
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
 \item{name}{name for the expression information}
+
+\item{...}{additional params to pass}
 
 \item{provenance}{provenance information (optional)
 information for the giotto object. Pass NULL to remove an expression object}

--- a/man/setFeatureInfo.Rd
+++ b/man/setFeatureInfo.Rd
@@ -5,7 +5,7 @@
 \alias{setFeatureInfo,giotto-method}
 \title{Set feature info}
 \usage{
-setFeatureInfo(gobject, ...)
+setFeatureInfo(gobject, x, feat_type = NULL, ...)
 
 \S4method{setFeatureInfo}{giotto}(
   gobject,
@@ -19,12 +19,12 @@ setFeatureInfo(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{x}{giottoPoints object or list of giottoPoints to set. Passing NULL
 will remove the specified giottoPoints object from the giotto object}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
+
+\item{...}{additional params to pass}
 
 \item{verbose}{be verbose}
 

--- a/man/setFeatureMetadata.Rd
+++ b/man/setFeatureMetadata.Rd
@@ -5,7 +5,7 @@
 \alias{setFeatureMetadata,giotto-method}
 \title{Set feature metadata}
 \usage{
-setFeatureMetadata(gobject, ...)
+setFeatureMetadata(gobject, x, spat_unit = NULL, feat_type = NULL, ...)
 
 \S4method{setFeatureMetadata}{giotto}(
   gobject,
@@ -21,14 +21,14 @@ setFeatureMetadata(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{x}{featMetaObj or list of featMetaObj to set. Passing NULL will
 reset a specified set of feature metadata in the giotto object.}
 
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
+
+\item{...}{additional params to pass}
 
 \item{provenance}{provenance information (optional)}
 

--- a/man/setGiottoImage.Rd
+++ b/man/setGiottoImage.Rd
@@ -5,28 +5,19 @@
 \alias{setGiottoImage,giotto-method}
 \title{Set giotto image object}
 \usage{
-setGiottoImage(gobject, ...)
+setGiottoImage(gobject, image, name = NULL, ...)
 
-\S4method{setGiottoImage}{giotto}(
-  gobject,
-  image,
-  image_type = NULL,
-  name = NULL,
-  initialize = FALSE,
-  verbose = NULL
-)
+\S4method{setGiottoImage}{giotto}(gobject, image, name = NULL, initialize = FALSE, verbose = NULL)
 }
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{image}{giotto image object to be attached without modification to the
 giotto object}
 
-\item{image_type}{deprecated}
-
 \item{name}{name of giotto image object}
+
+\item{...}{additional params to pass}
 
 \item{initialize}{(default = FALSE) whether to initialize the gobject before
 returning}

--- a/man/setGiottoImage.Rd
+++ b/man/setGiottoImage.Rd
@@ -5,14 +5,22 @@
 \alias{setGiottoImage,giotto-method}
 \title{Set giotto image object}
 \usage{
-setGiottoImage(gobject, image, name = NULL, ...)
+setGiottoImage(gobject, x, name = NULL, ...)
 
-\S4method{setGiottoImage}{giotto}(gobject, image, name = NULL, initialize = FALSE, verbose = NULL)
+\S4method{setGiottoImage}{giotto}(
+  gobject,
+  x,
+  name = NULL,
+  initialize = FALSE,
+  verbose = NULL,
+  ...,
+  image = deprecated()
+)
 }
 \arguments{
 \item{gobject}{giotto object}
 
-\item{image}{giotto image object to be attached without modification to the
+\item{x}{giotto image object to be attached without modification to the
 giotto object}
 
 \item{name}{name of giotto image object}
@@ -23,6 +31,8 @@ giotto object}
 returning}
 
 \item{verbose}{be verbose}
+
+\item{image}{deprecated. Use \code{x}}
 }
 \value{
 giotto object
@@ -43,7 +53,7 @@ g <- GiottoData::loadGiottoMini("vizgen")
 gimg <- getGiottoImage(gobject = g)
 
 setGiottoImage(g, NULL, name = objName(gimg))
-setGiottoImage(gobject = g, image = gimg)
+setGiottoImage(gobject = g, x = gimg)
 }
 \seealso{
 \code{\link{addGiottoImage}}

--- a/man/setMultiomics.Rd
+++ b/man/setMultiomics.Rd
@@ -5,23 +5,24 @@
 \alias{setMultiomics,giotto-method}
 \title{Set multiomics integration results}
 \usage{
-setMultiomics(gobject, result, spat_unit = NULL, feat_type = NULL, ...)
+setMultiomics(gobject, x, spat_unit = NULL, feat_type = NULL, ...)
 
 \S4method{setMultiomics}{giotto}(
   gobject,
-  result,
+  x,
   spat_unit = NULL,
   feat_type = NULL,
   integration_method = "WNN",
   result_name = "theta_weighted_matrix",
   verbose = TRUE,
-  ...
+  ...,
+  result = deprecated()
 )
 }
 \arguments{
 \item{gobject}{A Giotto object}
 
-\item{result}{A matrix or result from multiomics
+\item{x}{A matrix or result from multiomics
 integration (e.g. theta weighted values from runWNN)}
 
 \item{spat_unit}{spatial unit (e.g. 'cell')}
@@ -35,6 +36,8 @@ integration (e.g. theta weighted values from runWNN)}
 \item{result_name}{Default = 'theta_weighted_matrix'}
 
 \item{verbose}{be verbose}
+
+\item{result}{deprecated. Use \code{x}}
 }
 \value{
 A giotto object
@@ -46,7 +49,7 @@ Set a multiomics integration result in a Giotto object
 g <- GiottoData::loadGiottoMini("visium")
 
 setMultiomics(
-    gobject = g, result = matrix(rnorm(100), nrow = 10),
+    gobject = g, x = matrix(rnorm(100), nrow = 10),
     spat_unit = "cell", feat_type = "rna_protein"
 )
 }

--- a/man/setMultiomics.Rd
+++ b/man/setMultiomics.Rd
@@ -5,7 +5,7 @@
 \alias{setMultiomics,giotto-method}
 \title{Set multiomics integration results}
 \usage{
-setMultiomics(gobject, ...)
+setMultiomics(gobject, result, spat_unit = NULL, feat_type = NULL, ...)
 
 \S4method{setMultiomics}{giotto}(
   gobject,
@@ -21,14 +21,14 @@ setMultiomics(gobject, ...)
 \arguments{
 \item{gobject}{A Giotto object}
 
-\item{...}{additional params to pass}
-
 \item{result}{A matrix or result from multiomics
 integration (e.g. theta weighted values from runWNN)}
 
 \item{spat_unit}{spatial unit (e.g. 'cell')}
 
 \item{feat_type}{(e.g. 'rna_protein')}
+
+\item{...}{additional params to pass}
 
 \item{integration_method}{multiomics integration method used. Default = 'WNN'}
 

--- a/man/setNearestNetwork.Rd
+++ b/man/setNearestNetwork.Rd
@@ -5,15 +5,22 @@
 \alias{setNearestNetwork,giotto-method}
 \title{Set nearest neighbor network}
 \usage{
-setNearestNetwork(gobject, ...)
+setNearestNetwork(
+  gobject,
+  x,
+  spat_unit = NULL,
+  feat_type = NULL,
+  name = NULL,
+  ...
+)
 
 \S4method{setNearestNetwork}{giotto}(
   gobject,
   x,
   spat_unit = NULL,
   feat_type = NULL,
+  name = NULL,
   nn_type = "sNN",
-  name = "sNN.pca",
   provenance = NULL,
   verbose = TRUE,
   initialize = TRUE,
@@ -23,8 +30,6 @@ setNearestNetwork(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{x}{nnNetObj or list of nnNetObj. Passing NULL will remove a specified
 set of nearest neighbor network information from the gobject}
 
@@ -32,10 +37,12 @@ set of nearest neighbor network information from the gobject}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
-\item{nn_type}{"kNN" or "sNN"}
-
 \item{name}{name of NN network to be used
 yet supported.}
+
+\item{...}{additional params to pass}
+
+\item{nn_type}{"kNN" or "sNN"}
 
 \item{provenance}{provenance information (optional)}
 

--- a/man/setNearestNetwork.Rd
+++ b/man/setNearestNetwork.Rd
@@ -37,8 +37,8 @@ set of nearest neighbor network information from the gobject}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
-\item{name}{name of NN network to be used
-yet supported.}
+\item{name}{name of NN network to be used. NULL (default) takes the name
+from \code{x}, falling back to "sNN.pca" when \code{x} is unnamed}
 
 \item{...}{additional params to pass}
 

--- a/man/setPolygonInfo.Rd
+++ b/man/setPolygonInfo.Rd
@@ -25,7 +25,8 @@ information (see details)}
 
 \item{name}{(optional, character) name to assign to polygon and spatial unit
 that polygon might define. Only used for single giottoPolygon objects. Names
-are taken from a named list for multiple polygons.}
+are taken from a named list for multiple polygons. NULL (default) takes the
+name from \code{x}, falling back to "cell" when \code{x} is unnamed}
 
 \item{...}{additional params to pass}
 

--- a/man/setPolygonInfo.Rd
+++ b/man/setPolygonInfo.Rd
@@ -5,12 +5,12 @@
 \alias{setPolygonInfo,giotto-method}
 \title{Set polygon info}
 \usage{
-setPolygonInfo(gobject, ...)
+setPolygonInfo(gobject, x, name = NULL, ...)
 
 \S4method{setPolygonInfo}{giotto}(
   gobject,
   x,
-  name = "cell",
+  name = NULL,
   centroids_to_spatlocs = FALSE,
   verbose = TRUE,
   initialize = TRUE,
@@ -20,14 +20,14 @@ setPolygonInfo(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{x}{single object or named list of objects to set as polygon
 information (see details)}
 
 \item{name}{(optional, character) name to assign to polygon and spatial unit
 that polygon might define. Only used for single giottoPolygon objects. Names
 are taken from a named list for multiple polygons.}
+
+\item{...}{additional params to pass}
 
 \item{centroids_to_spatlocs}{if centroid information is discovered, whether
 to additionally set them as a set of spatial locations (default = FALSE)}

--- a/man/setSpatialEnrichment.Rd
+++ b/man/setSpatialEnrichment.Rd
@@ -5,14 +5,21 @@
 \alias{setSpatialEnrichment,giotto-method}
 \title{Set spatial enrichment}
 \usage{
-setSpatialEnrichment(gobject, ...)
+setSpatialEnrichment(
+  gobject,
+  x,
+  spat_unit = NULL,
+  feat_type = NULL,
+  name = NULL,
+  ...
+)
 
 \S4method{setSpatialEnrichment}{giotto}(
   gobject,
   x,
   spat_unit = NULL,
   feat_type = NULL,
-  name = "enrichment",
+  name = NULL,
   provenance = NULL,
   verbose = TRUE,
   initialize = TRUE,
@@ -22,8 +29,6 @@ setSpatialEnrichment(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{x}{spatEnrObj or list of spatEnrObj to set. Passing NULL will remove
 a specified set of spatial enrichment information from the gobject.}
 
@@ -32,6 +37,8 @@ a specified set of spatial enrichment information from the gobject.}
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
 \item{name}{name of spatial enrichment results. Default "DWLS"}
+
+\item{...}{additional params to pass}
 
 \item{provenance}{provenance information (optional)}
 

--- a/man/setSpatialEnrichment.Rd
+++ b/man/setSpatialEnrichment.Rd
@@ -36,7 +36,8 @@ a specified set of spatial enrichment information from the gobject.}
 
 \item{feat_type}{feature type (e.g. "rna", "dna", "protein")}
 
-\item{name}{name of spatial enrichment results. Default "DWLS"}
+\item{name}{name of spatial enrichment results. NULL (default) takes the
+name from \code{x}, falling back to "enrichment" when \code{x} is unnamed}
 
 \item{...}{additional params to pass}
 

--- a/man/setSpatialLocations.Rd
+++ b/man/setSpatialLocations.Rd
@@ -26,7 +26,8 @@ specified set of spatial locations data.}
 
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
-\item{name}{name of spatial locations, default "raw"}
+\item{name}{name of spatial locations. NULL (default) takes the name from
+\code{x}, falling back to "raw" when \code{x} is unnamed}
 
 \item{...}{additional params to pass}
 

--- a/man/setSpatialLocations.Rd
+++ b/man/setSpatialLocations.Rd
@@ -5,13 +5,13 @@
 \alias{setSpatialLocations,giotto-method}
 \title{Set spatial locations}
 \usage{
-setSpatialLocations(gobject, ...)
+setSpatialLocations(gobject, x, spat_unit = NULL, name = NULL, ...)
 
 \S4method{setSpatialLocations}{giotto}(
   gobject,
   x,
   spat_unit = NULL,
-  name = "raw",
+  name = NULL,
   provenance = NULL,
   verbose = TRUE,
   initialize = TRUE,
@@ -21,14 +21,14 @@ setSpatialLocations(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{x}{spatLocsObj or list of spatLocsObj. Passing NULL will remove a
 specified set of spatial locations data.}
 
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{name}{name of spatial locations, default "raw"}
+
+\item{...}{additional params to pass}
 
 \item{provenance}{provenance information (optional)}
 

--- a/man/setSpatialNetwork.Rd
+++ b/man/setSpatialNetwork.Rd
@@ -5,7 +5,7 @@
 \alias{setSpatialNetwork,giotto-method}
 \title{Set spatial network}
 \usage{
-setSpatialNetwork(gobject, ...)
+setSpatialNetwork(gobject, x, spat_unit = NULL, name = NULL, ...)
 
 \S4method{setSpatialNetwork}{giotto}(
   gobject,
@@ -21,14 +21,14 @@ setSpatialNetwork(gobject, ...)
 \arguments{
 \item{gobject}{giotto object}
 
-\item{...}{additional params to pass}
-
 \item{x}{spatialNetworkObj or list of spatialNetworkObj to set. Passing NULL
 removes a specified set of spatial network information from the gobject.}
 
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
 \item{name}{name of spatial network}
+
+\item{...}{additional params to pass}
 
 \item{provenance}{provenance name}
 

--- a/man/set_multiomics.Rd
+++ b/man/set_multiomics.Rd
@@ -32,7 +32,7 @@ Set a multiomics integration result in a Giotto object
 g <- GiottoData::loadGiottoMini("visium")
 
 set_multiomics(
-    gobject = g, result = matrix(rnorm(100), nrow = 10),
+    gobject = g, x = matrix(rnorm(100), nrow = 10),
     spat_unit = "cell", feat_type = "rna_protein"
 )
 }

--- a/man/stitchGiottoLargeImage.Rd
+++ b/man/stitchGiottoLargeImage.Rd
@@ -131,7 +131,7 @@ save the image as automatically.
 
 \examples{
 g <- GiottoData::loadGiottoMini("visium")
-g_image <- getGiottoImage(g, image_type = "largeImage")
+g_image <- getGiottoImage(g, name = list_images(g)$name[1])
 
 stitchGiottoLargeImage(largeImage_list = list(g_image))
 }

--- a/man/zoom.Rd
+++ b/man/zoom.Rd
@@ -31,7 +31,7 @@ is needed.
 }
 \examples{
 g <- GiottoData::loadGiottoMini("vizgen")
-gimg <- getGiottoImage(g, image_type = "largeImage")
+gimg <- getGiottoImage(g, name = list_images(g)$name[1])
 gpoly <- GiottoData::loadSubObjectMini("giottoPolygon")
 gpoints <- GiottoData::loadSubObjectMini("giottoPoints")
 e <- ext(6400, 6800, -4860, -4750) # arbitrary

--- a/tests/testthat/test-create_mini_vizgen.R
+++ b/tests/testthat/test-create_mini_vizgen.R
@@ -177,8 +177,8 @@ vizsubc <- calculateOverlap(
 
 
 # get values to test
-z0_gpoly <- getPolygonInfo(vizsubc, polygon_name = "z0", return_giottoPolygon = TRUE)
-z1_gpoly <- getPolygonInfo(vizsubc, polygon_name = "z1", return_giottoPolygon = TRUE)
+z0_gpoly <- getPolygonInfo(vizsubc, name = "z0", return_giottoPolygon = TRUE)
+z1_gpoly <- getPolygonInfo(vizsubc, name = "z1", return_giottoPolygon = TRUE)
 
 rna_pnts <- getFeatureInfo(vizsubc, feat_type = "rna", return_giottoPoints = TRUE)
 

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -194,9 +194,9 @@ test_that("Subsetting multiple spatial units works", {
     )
 
     # polys are cropped
-    z0_poly <- getPolygonInfo(g_out, polygon_name = "z0")
-    z1_poly <- getPolygonInfo(g_out, polygon_name = "z1")
-    agg_poly <- getPolygonInfo(g_out, polygon_name = "aggregate")
+    z0_poly <- getPolygonInfo(g_out, name = "z0")
+    z1_poly <- getPolygonInfo(g_out, name = "z1")
+    agg_poly <- getPolygonInfo(g_out, name = "aggregate")
 
     expect_true({
         terra::xmax(ext(centroids(z0_poly))) <= 6600 &&

--- a/tests/testthat/test_03_accessors.R
+++ b/tests/testthat/test_03_accessors.R
@@ -79,7 +79,7 @@ describe("Error handling: Gobject Getting Non-Existent Data", {
 
     it("Not found PolygonInfo returns error", {
         expect_error(
-            getPolygonInfo(g, polygon_name = "none")
+            getPolygonInfo(g, name = "none")
         )
     })
 
@@ -167,7 +167,7 @@ describe("Giotto Object Getters Work", {
     it("Finds PolygonInfo", {
         checkmate::expect_class(
             getPolygonInfo(viz,
-                polygon_name = "z0"
+                name = "z0"
             ),
             "SpatVector"
         )
@@ -319,7 +319,7 @@ describe("Giotto Object Setters Basic Functionalities", {
     # SPATINFO
 
     g <- setPolygonInfo(g,
-        x = getPolygonInfo(viz, polygon_name = "z0",
+        x = getPolygonInfo(viz, name = "z0",
             return_giottoPolygon = TRUE,
             verbose = FALSE
         )


### PR DESCRIPTION
## Summary

Aligns the slot accessors on one shared, discoverable formal contract. Four parts, in commit order.

**1. Widened generics.** All 24 slot-accessor S4 generics in `R/slot_accessors.R` go from `function(gobject, ...) standardGeneric(...)` to exposing contract-stable formals (`spat_unit`, `feat_type`, `name` per accessor). IDE autocomplete (RStudio, VSCode, lsp) now surfaces these past `gobject`, and the documented signature matches the dispatch contract. More importantly, S4 requires a method's formals to match the generic's for shared names and order — so the contract becomes *enforced* for downstream method authors rather than conventional.

**2. Setter `name` defaults.** These previously held the "fallback when both caller and subobject have no name" value (`"raw"`, `"pca"`, `"sNN.pca"`, `"enrichment"`, `"cell"`) in the formal slot, with `is.null(match.call()$name)` distinguishing supplied vs. default. That detection breaks once `name` is on the generic (S4 propagates the generic's NULL default symbolically into the method frame). Refactored to method default `name = NULL`, detection via `is.null(name)`, explicit body-side fallback after `read_s4_nesting()`.

`getExpression` adopts `name` as the canonical formal alongside `values` (now a back-compat alias); they error if both are supplied and differ.

| Setter | Old method default | Body fallback |
|---|---|---|
| `setExpression` | `name = "raw"` | `"raw"` |
| `setSpatialLocations` | `name = "raw"` | `"raw"` |
| `setDimReduction` | `name = "pca"` | `"pca"` |
| `setNearestNetwork` | `name = "sNN.pca"` | `"sNN.pca"` |
| `setSpatialEnrichment` | `name = "enrichment"` | `"enrichment"` |
| `setPolygonInfo` | `name = "cell"` | `"cell"` |
| `setSpatialNetwork` | `name = NULL` already | (no fallback case, unchanged) |

Because the default moved out of the signature, `?setExpression` showed `name = NULL` with no indication of what NULL does. Each `@param name` now states the fallback. This also corrects `setSpatialEnrichment`, whose documented default was already wrong before this PR (`"DWLS"`; the body falls back to `"enrichment"`).

**3. `image_type` removed** from `getGiottoImage()`, `setGiottoImage()`, `plotGiottoImage()` and `distGiottoImage()`. It was documented deprecated and never read in any of them: the accessors ignored it, `plotGiottoImage()` overwrote any supplied value by inspecting the class of the fetched image, and `distGiottoImage()` accepted only its default `"largeImage"` behind a gate that was always true.

This commit also repairs a call site the earlier commits broke: `reconnectGiottoImage()` still passed `image_type` into `getGiottoImage()` after the accessor formal was removed. No test reaches that path.

`list_images()` / `list_images_names()` keep their `img_type` argument — that one is a working filter with real callers, not the same parameter.

**4. Contract outliers renamed.** Three generics deviated from the naming the other 21 share, which only mattered once the formals moved onto the generics:

| Generic | Was | Now | Deprecated alias |
|---|---|---|---|
| `setMultiomics` | `result` | `x` | `result` |
| `setGiottoImage` | `image` | `x` | `image` |
| `getPolygonInfo` | `polygon_name` | `name` | `polygon_name` |

Old names keep working with a deprecation warning via `deprecate_param()`. Following the existing convention (`calculateOverlap(spatial_info)`, `getExpression(values)`), the aliases live on the methods and reach them through the generic's `...`, so **dispatch signatures are unchanged**. Positional calls are unaffected. 35 internal call sites moved to the canonical names.

## Method formal reorders (S4 conformity)

- `getDimReduction`: `name` moved ahead of `reduction` / `reduction_method`
- `getNearestNetwork`: `name` moved ahead of `nn_type`
- `setNearestNetwork`: `name` moved ahead of `nn_type`

## Compatibility

Widening is inert at runtime — method defaults win over generic defaults at value time. The renames are non-breaking via the aliases.

The one hard break is `image_type`. It went from "accepted and silently ignored" to removed without an intervening warning release. One caller exists in the suite, in Giotto.

## Downstream coordination

- **Must merge before this PR:** giotto-suite/Giotto — drops `image_type` from a `getGiottoImage()` call in `.reg_img_minmax_finder()` plus 4 lines in `test_98_visium.R`. Safe against current GiottoClass (the param is ignored there and `name = NULL` already resolves to the first image), so it can land at any time.
- **Must merge after this PR:** giotto-suite/Giotto and giotto-suite/GiottoVisuals — 8 call sites moving to the canonical argument names. These only warn today, but the canonical names *error* before this PR lands (`getPolygonInfo` has no `...` to absorb `name=`; `setMultiomics` leaves its required `result=` missing).
- **GiottoDisk:** unaffected. Defines no methods on these generics and calls none of the renamed arguments.

## Test plan

- [x] `devtools::test()`: FAIL 0 | PASS 998, unchanged from baseline
- [x] Targeted verification of the three deprecation aliases (canonical form works and is silent; alias form gives the same result and emits `lifecycle_warning_deprecated`; positional routing intact) — 16/16 assertions, since the suite has no alias coverage
- [x] Confirmed no method anywhere in the suite specializes the renamed argument positions, so the aliases are reachable
- [x] Smoke-tested `loadGiotto` round-trip via the standard `loadGiottoMini` path
