### PR TITLE
fix: giottoBinPoints through setFeatureInfo, overlap and expression write

### DIFF
--- a/R/classes-binpoints.R
+++ b/R/classes-binpoints.R
@@ -137,14 +137,31 @@ setMethod("calculateOverlap", signature("giottoPolygon", "giottoBinPoints"),
         if (!is.null(poly_subset_ids)) {
             x <- x[x$poly_ID %in% poly_subset_ids]
         }
-        overlap_data <- terra::extract(x[], y@spatial)
+
+        # On a project-managed giotto the polygons are store-backed, and
+        # terra::extract() has no method for a store. Materialize them into a
+        # working copy for the terra call: segmentation polygon counts are
+        # modest (~10^4-10^5) next to the bin1 points they are overlapped
+        # with (~10^6-10^7), which stay untouched in `y`. `x` itself is left
+        # alone so the object handed back keeps its store.
+        px <- x
+        if (!inherits(px[], "SpatVector")) {
+            GiottoUtils::package_check(
+                "GiottoDisk",
+                repository = "github:giotto-suite/GiottoDisk"
+            )
+            px[] <- GiottoDisk::storeRead(px[], output = "terra")
+        }
+        overlap_data <- terra::extract(px[], y@spatial)
         # res <- terra::relate(x[], y@spatial,
         #     relation = "intersects", pairs = TRUE) |>
         #     data.table::as.data.table()
         # names(res) <- c("poly_ID", "b")
         # res <- res[, .gbp_spatial_select_counts(y, b), by = "poly_ID"]
 
-        res <- .gbp_create_overlap_point_dt(x, y, overlap_data)
+        # built from the materialized copy: it reads `poly_ID` off the
+        # payload, which terra provides and a store need not
+        res <- .gbp_create_overlap_point_dt(px, y, overlap_data)
 
         if (isTRUE(return_gpolygon)) {
             # update schema metadata in overlap object

--- a/R/slot_accessors.R
+++ b/R/slot_accessors.R
@@ -1082,7 +1082,12 @@ setMethod("setExpression", signature("giotto"), function(gobject, x,
         if (inherits(mat, memory_matrix) || isTRUE(write)) {
             store <- GiottoDisk::sourceWrite(gsrc, mat)
             x@misc$uid <- store@uid
-            x[] <- GiottoDisk::storeRead(store)
+            # Keep the store itself, as setFeatureInfo() does. storeRead()
+            # returns the lazy Arrow query over it, which reports the
+            # triplet file's shape (nnz x 4) rather than features x cells
+            # and is not a `parquetExprStore`, so every downstream verb that
+            # dispatches on the store class silently misses.
+            x[] <- store
         }
     }
 
@@ -2853,9 +2858,23 @@ setMethod("setFeatureInfo", signature("giotto"), function(gobject, x,
     ))
   
     # write to disk if needed
+    #
+    # giottoBinPoints is held back deliberately. It has no `[` payload
+    # accessor (only character/logical/numeric indices), so `x[]` errors, and
+    # even with one the vault would take `@spatial` only -- while `@counts`
+    # holds the bulk. Worse, `@spatial` has to stay a terra SpatVector:
+    # calculateOverlap() and crop() call terra::extract() / terra::relate() on
+    # it directly, neither of which accepts a store. Storing it would break
+    # the bin1 overlap workflow. Revisit once giottoBinPoints has a
+    # store-backed representation for both slots.
     if (!is.null(gobject@source)) {
         gsrc <- .gsource(gobject)
-        if (!inherits(x[], "dataStore")) {
+        if (inherits(x, "giottoBinPoints")) {
+            vmsg(.v = verbose, sprintf(
+                "giottoBinPoints [%s] kept in memory; no disk representation",
+                featType(x)
+            ))
+        } else if (!inherits(x[], "dataStore")) {
             store <- GiottoDisk::sourceWrite(gsrc, x[])
             x[] <- store
         }
@@ -2869,9 +2888,17 @@ setMethod("setFeatureInfo", signature("giotto"), function(gobject, x,
 # Detect a 0-feature giottoPoints. Cheap path via cached IDs; falls back to
 # nrow when the cache is empty/unpopulated (which may query disk for
 # disk-backed representations).
+#
+# `unique_ID_cache` is a giottoPoints slot. giottoBinPoints reaches this from
+# setFeatureInfo() too and has no such slot, so read it only when present and
+# let that class take the nrow() path.
 .gpoints_is_empty <- function(x) {
     if (is.null(x)) return(FALSE)
-    cache <- methods::slot(x, "unique_ID_cache")
+    cache <- if ("unique_ID_cache" %in% methods::slotNames(x)) {
+        methods::slot(x, "unique_ID_cache")
+    } else {
+        character(0L)
+    }
     if (length(cache) > 0L) return(FALSE)
     n <- try(nrow(x), silent = TRUE)
     if (inherits(n, "try-error")) return(TRUE)


### PR DESCRIPTION
Fixes the bin1 → `calculateOverlap()` → `overlapToMatrix()` workflow — the one in the
`stereoseq_mouse_eyeball` article, and the path users take to bring their own cell
segmentation. It failed on **every** route, in memory as well as on disk.

Four defects, found in that order. Each was masking the next, which is why they land together.

### 1. `.gpoints_is_empty()` reads a slot `giottoBinPoints` does not have

It calls `methods::slot(x, "unique_ID_cache")` unconditionally. `giottoPoints` has that slot;
`giottoBinPoints` has `spatial`/`counts`/`bid`/`pmap`/`fid`/`compact` and no cache. `setFeatureInfo()`
routes both classes through it, so `load_binpoints = TRUE` errored out with
`no slot of name "unique_ID_cache"` — **with no backend involved**. Now read only when present,
letting the class take the existing `nrow()` path.

### 2. `setFeatureInfo()` tried to vault `giottoBinPoints`

On a backed giotto it does `sourceWrite(gsrc, x[])`. `giottoBinPoints` has `[` for
character/logical/numeric but no `i = "missing"` method, so the bare `x[]` threw
`object of type 'S4' is not subsettable`.

Adding that method would have been the wrong fix: `@spatial` **has to stay a terra SpatVector**,
because `calculateOverlap()` and `crop()` call `terra::extract()` / `terra::relate()` on it
directly. Storing it would have broken the very workflow this PR restores — and it would only
have vaulted the coordinates anyway, while `@counts` holds the bulk. It is now held in memory
with a verbose note, until `giottoBinPoints` has a store-backed representation for both slots.

### 3. `calculateOverlap(giottoPolygon, giottoBinPoints)` assumed a terra payload

`terra::extract(x[], y@spatial)` — but on a backed giotto `x[]` is a `parquetGeomStore`, so
`unable to find an inherited method for 'extract'`. Polygons are now materialized into a
working copy for the terra call. Segmentation polygon counts are modest (10^4–10^5) next to the
bin1 points they overlap (10^6–10^7), which are never materialized, and the object handed back
keeps its store.

### 4. `setExpression()` stored the query instead of the store

```r
x[] <- GiottoDisk::storeRead(store)   # was
x[] <- store                          # now
```

`storeRead()` returns the lazy Arrow query. It reports the triplet file's shape (`nnz x 4`)
rather than features × cells, and is not a `parquetExprStore`, so every downstream verb that
dispatches on the store class silently misses. `setFeatureInfo()` already did this correctly.

**This one is not binpoints-specific.** It fires whenever an in-memory matrix is set onto a
backed giotto. Xenium never hits it because `overlapToMatrix()` writes a `parquetExprStore`
directly, so it has been latent. Worth a close look.

## Verification

Real Stereo-seq bin1 (`C04687E314.tissue.gef`): 13,810,164 points over 5,043,144 bins,
overlapped against HE-mask polygons.

| | in-memory | `backend =` |
|---|---|---|
| expression payload | `dgCMatrix` | `parquetExprStore` |
| dim | 26,535 × 7,554 | 26,535 × 7,554 |
| nnz | 3,686,538 | 3,686,538 |

Dimnames and both margins identical. Before this PR the in-memory route errored at `create`
and the backed route errored at `calculateOverlap`.

Test suite, patched vs pristine `gsource` in the same environment:

| | pass | fail | error |
|---|---|---|---|
| `gsource` | 922 | 0 | 12 |
| this branch | **929** | 0 | **10** |

Two previously-erroring tests now pass; no new failures. The remaining 10 are missing optional
packages in my environment (`geometry`, `exactextractr`, `stars`) plus two pre-existing
`setSpatialLocations` entry-count mismatches in `test-networks.R`, identical on both sides.

## For review

- **Base is `gsource`, not `dev`.** This branch is cut from `gsource` and pairs with the
  on-disk line of work. `CLAUDE.md` says PRs target `dev` — redirect if you'd rather.
- Fix 3 puts store-materialization inside GiottoClass. The cleaner alternative is payload-level
  dispatch in GiottoDisk (`calculateOverlap(parquetGeomStore, giottoBinPoints)`), which I did not
  take because it splits the change across two repos. Happy to move it.
- `calculateOverlap()`'s `poly_subset_ids` branch still does `x[x$poly_ID %in% ...]` against a
  possibly-store payload. Left alone as an independent pre-existing question; not exercised here.
- Independent of GiottoDisk#41 / Giotto#1272 — binpoints was never part of those.
