### PR TITLE
Select group cells by cell_ID in create_average_DT / create_average_detection_DT

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # GiottoClass 0.5.2
 
+## bug fixes
+- `create_average_DT()` and `create_average_detection_DT()` now select each group's cells by `cell_ID` rather than by position. Both fetch the expression matrix and the cell metadata independently, and nothing guarantees the two share a cell order — a freshly created object happens to agree, but `GiottoData::loadGiottoMini("visium")` has none of its 624 cells in matching position. Where the orders diverged, cells were labelled with another cell's group: on that object the per-cluster means correlated only 0.77 with the correct values. **Results will change for affected objects**; they were wrong before.
+
 ## changes
 - shared-domain and spatial-domain accessors promoted to S4 generics on `signature("giotto")` — `getCellMetadata` / `setCellMetadata`, `getFeatureMetadata` / `setFeatureMetadata`, `getExpression` / `setExpression`, `getMultiomics` / `setMultiomics`, `getDimReduction` / `setDimReduction`, `getNearestNetwork` / `setNearestNetwork`, `getSpatialEnrichment` / `setSpatialEnrichment`, `getSpatialLocations` / `setSpatialLocations`, `getSpatialNetwork` / `setSpatialNetwork`, `getPolygonInfo` / `setPolygonInfo`, `getFeatureInfo` / `setFeatureInfo`, `getGiottoImage` / `setGiottoImage`. Per-accessor internal/external split helpers (`.external_accessor_*` sentinel pattern) inlined into the public setters.
 - `overlapPointDT[i]` / `[, j]` default flipped from `ids = TRUE` → `ids = FALSE`. Default single-axis subset now returns an `overlapPointDT` subset object (matching `overlapIntensityDT` and `SpatVector`). The integer-index selection form is still available via `ovlp[i, ids = TRUE]`.

--- a/R/auxilliary.R
+++ b/R/auxilliary.R
@@ -779,6 +779,23 @@ addFeatMetadata <- function(gobject,
 # expression ####
 
 
+# Row order to put cell metadata into expression-column order.
+#
+# `getExpression()` and `getCellMetadata()` are fetched independently and the
+# suite makes no guarantee that they share a cell order.
+.expr_cell_order <- function(cell_metadata, expr_data) {
+    ord <- match(colnames(expr_data), cell_metadata[["cell_ID"]])
+    if (anyNA(ord)) {
+        stop(
+            "expression columns and cell metadata do not describe the same ",
+            "cells; cannot align them.",
+            call. = FALSE
+        )
+    }
+    ord
+}
+
+
 #' @title create_average_DT
 #' @description calculates average gene expression for a cell metadata
 #' factor (e.g. cluster)
@@ -832,8 +849,12 @@ create_average_DT <- function(gobject,
     )
     myrownames <- rownames(expr_data)
 
+    # taken before the reorder so output column order is unchanged
+    groups <- unique(cell_metadata[[meta_data_name]])
+    cell_metadata <- cell_metadata[.expr_cell_order(cell_metadata, expr_data)]
+
     savelist <- list()
-    for (group in unique(cell_metadata[[meta_data_name]])) {
+    for (group in groups) {
         name <- paste0("cluster_", group)
 
         temp <- expr_data[, cell_metadata[[meta_data_name]] == group]
@@ -903,8 +924,11 @@ create_average_detection_DT <- function(gobject,
     )
     myrownames <- rownames(expr_data)
 
+    groups <- unique(cell_metadata[[meta_data_name]])
+    cell_metadata <- cell_metadata[.expr_cell_order(cell_metadata, expr_data)]
+
     savelist <- list()
-    for (group in unique(cell_metadata[[meta_data_name]])) {
+    for (group in groups) {
         name <- paste0("cluster_", group)
 
         temp <- expr_data[, cell_metadata[[meta_data_name]] == group]

--- a/tests/testthat/test_11_average_DT_alignment.R
+++ b/tests/testthat/test_11_average_DT_alignment.R
@@ -1,0 +1,67 @@
+
+# create_average_DT() and create_average_detection_DT() fetch the expression
+# matrix and the cell metadata independently. Nothing guarantees the two share
+# a cell order, so the grouping has to be keyed on cell_ID rather than assumed
+# positional.
+
+g <- GiottoData::loadGiottoMini("visium", verbose = FALSE)
+EX <- getExpression(g, values = "normalized", output = "matrix")
+MD <- getCellMetadata(g, output = "data.table")
+CLUS <- "leiden_clus"
+
+# reference computed by selecting cells by identifier, never by position
+.ref_by_id <- function(fun) {
+    lv <- unique(MD[[CLUS]])
+    out <- vapply(lv, function(k) {
+        ids <- MD[get(CLUS) == k][["cell_ID"]]
+        fun(EX[, colnames(EX) %in% ids, drop = FALSE])
+    }, numeric(nrow(EX)))
+    colnames(out) <- paste0("cluster_", lv)
+    out
+}
+
+test_that("create_average_DT selects cells by identifier, not position", {
+    got <- as.matrix(create_average_DT(g,
+        meta_data_name = CLUS, expression_values = "normalized"
+    ))
+    ref <- .ref_by_id(Matrix::rowMeans)
+    expect_equal(got[, colnames(ref)], ref, ignore_attr = TRUE)
+})
+
+test_that("create_average_detection_DT selects cells by identifier", {
+    got <- as.matrix(create_average_detection_DT(g,
+        meta_data_name = CLUS, expression_values = "normalized",
+        detection_threshold = 0
+    ))
+    ref <- .ref_by_id(function(m) Matrix::rowSums(m > 0) / ncol(m))
+    expect_equal(got[, colnames(ref)], ref, ignore_attr = TRUE)
+})
+
+test_that("results are invariant to cell metadata row order", {
+    # The property that actually matters, independent of any one fixture's
+    # incidental ordering: permuting the metadata must not change the answer.
+    cm <- getCellMetadata(g, output = "cellMetaObj")
+    set.seed(9)
+    cm[] <- cm[][sample(nrow(cm[]))]
+    g2 <- setGiotto(g, cm, verbose = FALSE)
+
+    a <- create_average_DT(g,
+        meta_data_name = CLUS, expression_values = "normalized")
+    b <- create_average_DT(g2,
+        meta_data_name = CLUS, expression_values = "normalized")
+    expect_equal(a[, sort(colnames(a))], b[, sort(colnames(b))])
+
+    a <- create_average_detection_DT(g,
+        meta_data_name = CLUS, expression_values = "normalized")
+    b <- create_average_detection_DT(g2,
+        meta_data_name = CLUS, expression_values = "normalized")
+    expect_equal(a[, sort(colnames(a))], b[, sort(colnames(b))])
+})
+
+test_that("output column order is unchanged by the alignment", {
+    # groups are enumerated before the reorder, so callers that index the
+    # result positionally are unaffected
+    got <- create_average_DT(g,
+        meta_data_name = CLUS, expression_values = "normalized")
+    expect_equal(colnames(got), paste0("cluster_", unique(MD[[CLUS]])))
+})


### PR DESCRIPTION
Both helpers fetch the expression matrix and the cell metadata independently,
then index expression columns with a bare metadata mask:

```r
temp <- expr_data[, cell_metadata[[meta_data_name]] == group]
```

Nothing guarantees the two share a cell order. A freshly created object happens
to agree, but `GiottoData::loadGiottoMini("visium")` has **none of its 624
cells in matching position**. Where the orders diverge, cells are labelled with
another cell's group — silently, with no error.

Measured on that object: per-cluster means correlate **0.77** with the correct
values, deviating by up to **6.29**.

Both helpers now reorder the metadata into expression-column order once, so the
loop bodies are untouched. Group order is captured before the reorder, so output
column order is unchanged for callers that index positionally.

`match()` rather than sorting or joining — only the small metadata table moves,
where sorting would have to permute the expression matrix itself.

## Tests

Beyond checking against an id-keyed reference, the suite asserts the property
that holds independently of any fixture's incidental ordering: **results are
invariant to permuting the metadata rows.** Full GiottoClass suite passes.

## Blast radius

`create_average_DT()` is exported, and both helpers feed:

- `findGiniMarkers()` / `findGiniMarkers_one_vs_all()` (Giotto)
- `spatial_interaction.R` (Giotto)
- the clustering helper in this file

**Results change for affected objects** — they were wrong before.

The same positional assumption exists separately in Giotto's
`findScranMarkers()`, which passes `cell_metadata[[cluster_column]]` straight to
`scran::findMarkers()`. That needs its own fix and is not covered here.